### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/python/lsst/p_lsstSwig.i
+++ b/python/lsst/p_lsstSwig.i
@@ -49,7 +49,7 @@
 %include "std_set.i"
 %include "std_vector.i"
 %include "std_iostream.i"
-%include "boost_shared_ptr.i"
+%include "std_shared_ptr.i"
 %include "carrays.i"
 %include "typemaps.i"
 
@@ -274,8 +274,8 @@ namespace boost {
 //
 %define %castShared(DERIVED, BASE)
     %extend DERIVED {
-        static boost::shared_ptr< DERIVED > cast(boost::shared_ptr< BASE > p) {
-            return boost::dynamic_pointer_cast< DERIVED >(p);
+        static std::shared_ptr< DERIVED > cast(std::shared_ptr< BASE > p) {
+            return std::dynamic_pointer_cast< DERIVED >(p);
         }
     }
 %enddef


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
