### PR TITLE
Ignore ttf files in fileDescriptor test

### DIFF
--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -125,7 +125,7 @@ class MemoryTestCase(unittest.TestCase):
         now_open = _get_open_files()
 
         # Some files are opened out of the control of the stack.
-        now_open = set(f for f in now_open if not f.endswith(".car"))
+        now_open = set(f for f in now_open if not f.endswith(".car") and not f.endswith(".ttf"))
 
         diff = now_open.difference(open_files)
         if diff:


### PR DESCRIPTION
 Fix the rgb.py test problem by ignoring .ttf files.