### PR TITLE
Ensure Swig wraps std::type_info correctly.

### DIFF
--- a/python/lsst/p_lsstSwig.i
+++ b/python/lsst/p_lsstSwig.i
@@ -279,3 +279,12 @@ namespace boost {
         }
     }
 %enddef
+
+%{
+#include <typeinfo>
+%}
+
+%nodefaultctor std::type_info;
+class std::type_info {};
+
+%useValueEquality(std::type_info)


### PR DESCRIPTION
PropertySet relies on type_info's equality operator working properly,
even though it previously wasn't being wrapped.  I'm not sure how it
ever worked before, but it's certainly safer now.