### PR TITLE
DM-7186: Do not fail if tests leave SSSD passwd file open.

### DIFF
--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -177,7 +177,8 @@ class MemoryTestCase(unittest.TestCase):
         now_open = _get_open_files()
 
         # Some files are opened out of the control of the stack.
-        now_open = set(f for f in now_open if not f.endswith(".car") and not f.endswith(".ttf"))
+        now_open = set(f for f in now_open if not f.endswith(".car") and not f.endswith(".ttf")
+                                              and f != "/var/lib/sss/mc/passwd")
 
         diff = now_open.difference(open_files)
         if diff:


### PR DESCRIPTION
This happens on the new (August 2016) NCSA LDAP infrastructure; it's triggered
by:

  from eups import Eups