### PR TITLE
Fix bug in handling of rtol=None, with tests to exercise it.

### DIFF
--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -600,8 +600,15 @@ def assertFloatsAlmostEqual(testCase, lhs, rhs, rtol=sys.float_info.epsilon,
     errMsg = []
     if failed:
         if numpy.isscalar(bad):
-            errMsg = ["%s %s %s; diff=%s/%s=%s with rtol=%s, atol=%s"
-                      % (lhs, cmpStr, rhs, absDiff, relTo, absDiff/relTo, rtol, atol)]
+            if rtol is None:
+                errMsg = ["%s %s %s; diff=%s with atol=%s"
+                          % (lhs, cmpStr, rhs, absDiff, atol)]
+            elif atol is None:
+                errMsg = ["%s %s %s; diff=%s/%s=%s with rtol=%s"
+                          % (lhs, cmpStr, rhs, absDiff, relTo, absDiff/relTo, rtol)]
+            else:
+                errMsg = ["%s %s %s; diff=%s/%s=%s with rtol=%s, atol=%s"
+                          % (lhs, cmpStr, rhs, absDiff, relTo, absDiff/relTo, rtol, atol)]
         else:
             errMsg = ["%d/%d elements %s with rtol=%s, atol=%s"
                       % (bad.sum(), bad.size, failStr, rtol, atol)]
@@ -622,8 +629,12 @@ def assertFloatsAlmostEqual(testCase, lhs, rhs, rtol=sys.float_info.epsilon,
                     lhs = numpy.ones(bad.shape, dtype=float) * lhs
                 if numpy.isscalar(rhs):
                     rhs = numpy.ones(bad.shape, dtype=float) * rhs
-                for a, b, diff, rel in zip(lhs[bad], rhs[bad], absDiff[bad], relTo[bad]):
-                    errMsg.append("%s %s %s (diff=%s/%s=%s)" % (a, cmpStr, b, diff, rel, diff/rel))
+                if rtol is None:
+                    for a, b, diff in zip(lhs[bad], rhs[bad], absDiff[bad]):
+                        errMsg.append("%s %s %s (diff=%s)" % (a, cmpStr, b, diff))
+                else:
+                    for a, b, diff, rel in zip(lhs[bad], rhs[bad], absDiff[bad], relTo[bad]):
+                        errMsg.append("%s %s %s (diff=%s/%s=%s)" % (a, cmpStr, b, diff, rel, diff/rel))
 
     if msg is not None:
         errMsg.append(msg)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,6 +91,53 @@ class UtilsTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(self.larges, self.largesOneOff, atol=1e-7)
         self.assertFloatsAlmostEqual(self.ranges, self.rangesEpsilon, rtol=1E-3, atol=1E-4)
 
+        # Test that it raises appropriately
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.large, 0.)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.large, 0., rtol=1E-2)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.large, 0., rtol=1E-2, atol=None)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.large, 0., atol=1e-2)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.large, 0., atol=1e-2, rtol=None)
+
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, 0.)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, 0., rtol=1E-2)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, 0., rtol=1E-2, atol=None)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, 0., atol=1e-2)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, 0., atol=1e-2, rtol=None)
+
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(0., self.larges)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(0., self.larges, rtol=1E-2)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(0., self.larges, rtol=1E-2, atol=None)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(0., self.larges, atol=1e-2)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(0., self.larges, atol=1e-2, rtol=None)
+
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon, rtol=1E-16)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon, rtol=1E-16, atol=None)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon, rtol=1E-16, relTo=100.0)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, self.largesOneOff, atol=1e-16)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.larges, self.largesOneOff, atol=1e-16, rtol=None)
+        with self.assertRaises(AssertionError):
+            self.assertFloatsAlmostEqual(self.ranges, self.rangesEpsilon, rtol=1E-15, atol=1E-4)
+
         if display:
             # should see failures on the center row of the 5x5 image, but not the very center point
             nonzeroCenter = self.zeros.copy()


### PR DESCRIPTION
If rtol=None is specified and the assert fails, the method bails with a
TypeError becaues it tries to divide by rtol when constructing errMsg. I'm
surprised noone had encountered this before.