### PR TITLE
DM-7137: utils raDecStr delimiters are untested and don't work

### DIFF
--- a/src/RaDecStr.cc
+++ b/src/RaDecStr.cc
@@ -1,7 +1,7 @@
-/* 
+/*
  * LSST Data Management System
  * Copyright 2008, 2009, 2010 LSST Corporation.
- * 
+ *
  * This product includes software developed by the
  * LSST Project (http://www.lsst.org/).
  *
@@ -9,22 +9,21 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the LSST License Statement and 
- * the GNU General Public License along with this program.  If not, 
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
- 
+
 #include <string>
 
 #include "lsst/utils/RaDecStr.h"
 
-using namespace std;
 namespace except = lsst::pex::exceptions;
 
 /**
@@ -35,7 +34,7 @@ radians into strings and back again.
 
 Right ascensions and declinations (raDecs) are easiest read as strings
 in the form hh:mm:ss.ss +dd:mm::ss.s, but for calculations, they need
-to be in degrees or radians. These functions perform those calculations. 
+to be in degrees or radians. These functions perform those calculations.
 The function names themselves use the following abbreviations
 
 - <STRONG>ra</STRONG> Right Ascension
@@ -56,7 +55,6 @@ The default delimiter (the colon) can be supplied as an optional argument
 */
 
 
-using namespace std;
 namespace ut = lsst::utils;
 
 double radToDeg(long double angleInRadians) {
@@ -73,38 +71,38 @@ double degToRad(long double angleInDegrees) {
 
 ///Convert a right ascension in radians to a string format
 ///\param raRad Ra in radians
-string ut::raRadToStr(double raRad ) {
+std::string ut::raRadToStr(double raRad ) {
     return raDegToStr( radToDeg(raRad) );
 }
-    
-string ut::raDegToStr(double raDeg){
+
+std::string ut::raDegToStr(double raDeg){
 
     double ra = raDeg;  //Shorthand
-    
+
     //Convert to seconds of arc
     ra = round(ra*1e6)/1e6;
     ra *= 86400/360;
-    
+
     int hr = (int) floor(ra/3600.);
     ra -= hr*3600;
-    
+
     int mn = (int) floor(ra/60.);
     ra -= mn*60;    //Only seconds remain
-    
-    return str( boost::format("%02i:%02i:%05.2f") % hr % mn % ra);
-}
-    
 
-string ut::decRadToStr(double decRad) {
+    return boost::str( boost::format("%02i:%02i:%05.2f") % hr % mn % ra);
+}
+
+
+std::string ut::decRadToStr(double decRad) {
     return decDegToStr( radToDeg(decRad) );
 }
 
-    
-string ut::decDegToStr(double decDeg) {
+
+std::string ut::decDegToStr(double decDeg) {
 
     double dec = decDeg;    //Shorthand
-    
-    string sgn = (dec<0) ? "-" : "+";
+
+    std::string sgn = (dec<0) ? "-" : "+";
 
     //Rounding the declination prevents 14.999999999 being represented
     //as 14.:59:60.00
@@ -119,29 +117,29 @@ string ut::decDegToStr(double decDeg) {
     double sec = dec*3600;
     sec = floor(sec*100)/100.;
 
-    string str = sgn;
+    std::string str = sgn;
     return boost::str(boost::format("%s%02i:%02i:%05.2f") % sgn % degrees % min % sec);
-   
-}
-    
 
-string ut::raDecRadToStr(double raRad, double decRad) {
-    string val = raRadToStr(raRad);
+}
+
+
+std::string ut::raDecRadToStr(double raRad, double decRad) {
+    std::string val = raRadToStr(raRad);
     val = val + " "+decRadToStr(decRad);
     return val;
 }
 
-    
-string ut::raDecDegToStr(double raDeg, double decDeg) {
-    string val = raDegToStr(raDeg);
+
+std::string ut::raDecDegToStr(double raDeg, double decDeg) {
+    std::string val = raDegToStr(raDeg);
     val = val + " "+decDegToStr(decDeg);
     return val;
 }
 
 
-    
 
-    
+
+
 // ////////////////////////////////////////////////////////////////
 
 //
@@ -154,34 +152,34 @@ double ut::raStrToRad(std::string raStr, std::string delimiter) {
 
 
 double ut::raStrToDeg(std::string raStr, std::string delimiter) {
-    
+
     //Regex the hours, minutes and seconds
-    string regexStr = "(\\d+)";
+    std::string regexStr = "(\\d+)";
     regexStr.append(delimiter);
     regexStr.append("(\\d+)");
-    regexStr.append(delimiter);    
+    regexStr.append(delimiter);
     regexStr.append("([\\d\\.]+)");
-    
+
          static const boost::regex re(regexStr);
     boost::cmatch what;
-    //This throws an exception of failure. I could catch it, 
+    //This throws an exception of failure. I could catch it,
     //but I'd only throw it again
     if(! boost::regex_match(raStr.c_str(), what, re)) {
-        string msg= boost::str(boost::format("Failed to parse %s as a declination") % raStr);
+        std::string msg= boost::str(boost::format("Failed to parse %s as a declination") % raStr);
         throw LSST_EXCEPT(except::RuntimeError, msg);
-    }  
-       
+    }
+
 
     //Convert strings to doubles. Again, errors thrown on failure
-    double hours = std::stod(string(what[1].first, what[1].second));
-    double mins = std::stod(string(what[2].first, what[2].second));
-    double secs = std::stod(string(what[3].first, what[3].second));
-    
+    double hours = std::stod(std::string(what[1].first, what[1].second));
+    double mins = std::stod(std::string(what[2].first, what[2].second));
+    double secs = std::stod(std::string(what[3].first, what[3].second));
+
     double raDeg = secs/3600.;
     raDeg += mins/60.;
     raDeg += hours;
     raDeg *= 360./24.;
-    
+
     //printf("%g %g %g --> %g\n", hours, mins, secs, raDeg);
     return raDeg;
 
@@ -194,37 +192,37 @@ double ut::decStrToRad(std::string decStr, std::string delimiter) {
 
 
 double ut::decStrToDeg(std::string decStr, std::string delimiter) {
-    
+
     //Regex the degrees, minutes and seconds
-    string regexStr = "([\\d]+)";
+    std::string regexStr = "([\\d]+)";
     regexStr.append(delimiter);
     regexStr.append("(\\d+)");
-    regexStr.append(delimiter);    
+    regexStr.append(delimiter);
     regexStr.append("([\\d\\.]+)");
-    
+
      //http://www.boost.org/doc/libs/1_40_0/libs/regex/doc/html/boost_regex/captures.html
     static const boost::regex re(regexStr);
     boost::cmatch what;
 
     if(! boost::regex_search(decStr.c_str(), what, re)) {
-        string msg= boost::str(boost::format("Failed to parse %s as a declination") % decStr);
+        std::string msg= boost::str(boost::format("Failed to parse %s as a declination") % decStr);
         throw LSST_EXCEPT(except::RuntimeError, msg);
-    }  
+    }
 
     //Convert strings to doubles. Automatically pass the exception up the stack
-    double degrees = std::stod(string(what[1].first, what[1].second));
-    double mins = std::stod(string(what[2].first, what[2].second));
-    double secs = std::stod(string(what[3].first, what[3].second));
-    
+    double degrees = std::stod(std::string(what[1].first, what[1].second));
+    double mins = std::stod(std::string(what[2].first, what[2].second));
+    double secs = std::stod(std::string(what[3].first, what[3].second));
+
     degrees += ((secs/60.) +mins)/60.;
-    
+
     //Search for the presence of a minus sign. This approach catches the case of -0 degrees
-    string pmStr = "^-";
+    std::string pmStr = "^-";
     static const boost::regex pm(pmStr);
     if(boost::regex_search(decStr, pm)) {
         degrees *= -1;
     }
-    
+
     return degrees;
 }
 

--- a/src/RaDecStr.cc
+++ b/src/RaDecStr.cc
@@ -147,7 +147,7 @@ std::string ut::raDecDegToStr(double raDeg, double decDeg) {
 //
 
 double ut::raStrToRad(std::string raStr, std::string delimiter) {
-    return degToRad( raStrToDeg(raStr) );
+    return degToRad( raStrToDeg(raStr, delimiter) );
 }
 
 
@@ -160,12 +160,13 @@ double ut::raStrToDeg(std::string raStr, std::string delimiter) {
     regexStr.append(delimiter);
     regexStr.append("([\\d\\.]+)");
 
-         static const boost::regex re(regexStr);
+    const boost::regex re(regexStr);
     boost::cmatch what;
     //This throws an exception of failure. I could catch it,
     //but I'd only throw it again
     if(! boost::regex_match(raStr.c_str(), what, re)) {
-        std::string msg= boost::str(boost::format("Failed to parse %s as a declination") % raStr);
+        std::string msg= boost::str(boost::format("Failed to parse %s as a right ascension with regex %s")
+                                    % raStr % regexStr);
         throw LSST_EXCEPT(except::RuntimeError, msg);
     }
 
@@ -187,25 +188,26 @@ double ut::raStrToDeg(std::string raStr, std::string delimiter) {
 
 
 double ut::decStrToRad(std::string decStr, std::string delimiter) {
-    return degToRad( decStrToDeg(decStr) );
+    return degToRad( decStrToDeg(decStr, delimiter) );
 }
 
 
 double ut::decStrToDeg(std::string decStr, std::string delimiter) {
 
     //Regex the degrees, minutes and seconds
-    std::string regexStr = "([\\d]+)";
+    std::string regexStr = "(\\d+)";
     regexStr.append(delimiter);
     regexStr.append("(\\d+)");
     regexStr.append(delimiter);
     regexStr.append("([\\d\\.]+)");
 
      //http://www.boost.org/doc/libs/1_40_0/libs/regex/doc/html/boost_regex/captures.html
-    static const boost::regex re(regexStr);
+    const boost::regex re(regexStr);
     boost::cmatch what;
 
     if(! boost::regex_search(decStr.c_str(), what, re)) {
-        std::string msg= boost::str(boost::format("Failed to parse %s as a declination") % decStr);
+        std::string msg= boost::str(boost::format("Failed to parse %s as a declination with regex %s")
+                                    % decStr % regexStr);
         throw LSST_EXCEPT(except::RuntimeError, msg);
     }
 

--- a/tests/testRaDecToStr.py
+++ b/tests/testRaDecToStr.py
@@ -34,7 +34,7 @@ class RaDecToStrTestCase(lsst.utils.tests.TestCase):
 
     def setUp(self):
         self.goodData = [
-            # Ra (deg)      Dec (deg)   Ra (rad)    Dec (rad)   Ra (str)       Dec (str)
+            # Ra (deg)      Dec (deg)      Ra (str)       Dec (str)
             [0.00000000, 0.00000000,   "00:00:00.00", "+00:00:00.00"],
             [0.00027778, 0.00000000,   "00:00:00.07", "+00:00:00.00"],
             [0.00416667, 0.00000000,   "00:00:01.00", "+00:00:00.00"],

--- a/tests/testRaDecToStr.py
+++ b/tests/testRaDecToStr.py
@@ -92,6 +92,24 @@ class RaDecToStrTestCase(lsst.utils.tests.TestCase):
             self.assertAlmostEqual(lsstutils.raStrToDeg(raStr), raDeg, 4)
             self.assertAlmostEqual(lsstutils.decStrToDeg(decStr), decDeg, 3)
 
+    def testStrToRadDelim(self):
+        for raDeg, decDeg, raStr, decStr in self.goodData:
+            raRad = raDeg*math.pi/180.
+            decRad = decDeg*math.pi/180.
+            for delim in ['_', ' ']:
+                self.assertAlmostEqual(
+                    lsstutils.raStrToRad(raStr.replace(':', delim), delim), raRad, 6)
+                self.assertAlmostEqual(
+                    lsstutils.decStrToRad(decStr.replace(':', delim), delim), decRad, 6)
+
+    def testStrToDegDelim(self):
+        for raDeg, decDeg, raStr, decStr in self.goodData:
+            for delim in ['_', ' ']:
+                self.assertAlmostEqual(
+                    lsstutils.raStrToDeg(raStr.replace(':', delim), delim), raDeg, 4)
+                self.assertAlmostEqual(
+                    lsstutils.decStrToDeg(decStr.replace(':', delim), delim), decDeg, 3)
+
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testRaDecToStr.py
+++ b/tests/testRaDecToStr.py
@@ -19,8 +19,6 @@
 # the GNU General Public License along with this program.  If not,
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
-from builtins import range
-
 import sys
 import math
 import unittest
@@ -57,45 +55,22 @@ class RaDecToStrTestCase(lsst.utils.tests.TestCase):
             [120,        -90,          "08:00:00.00", "-90:00:00.00"],
         ]
 
-        self.raDegCol = 0
-        self.decDegCol = 1
-        self.raStrCol = 2
-        self.decStrCol = 3
-        self.num = len(self.goodData)
-
     # Testing numbers to strings
 
-    def testRaRadToStr(self):
-        for i in range(self.num):
-            raDeg = self.goodData[i][self.raDegCol]
+    def testRadToStr(self):
+        for raDeg, decDeg, raStr, decStr in self.goodData:
             raRad = raDeg*math.pi/180.
-            raStr = self.goodData[i][self.raStrCol]
-            self.assertEqual(lsstutils.raRadToStr(raRad), raStr)
-
-    def testRaDegToStr(self):
-        for i in range(self.num):
-            raDeg = self.goodData[i][self.raDegCol]
-            raStr = self.goodData[i][self.raStrCol]
-            self.assertEqual(lsstutils.raDegToStr(raDeg), raStr)
-
-    def testDecRadToStr(self):
-        for i in range(self.num):
-            decDeg = self.goodData[i][self.decDegCol]
             decRad = decDeg*math.pi/180.
-            decStr = self.goodData[i][self.decStrCol]
-
+            self.assertEqual(lsstutils.raRadToStr(raRad), raStr)
             self.assertEqual(lsstutils.decRadToStr(decRad), decStr)
 
-    def testDecDegToStr(self):
-        for i in range(self.num):
-            decDeg = self.goodData[i][self.decDegCol]
-            decStr = self.goodData[i][self.decStrCol]
+    def testDegToStr(self):
+        for raDeg, decDeg, raStr, decStr in self.goodData:
+            self.assertEqual(lsstutils.raDegToStr(raDeg), raStr)
             self.assertEqual(lsstutils.decDegToStr(decDeg), decStr)
 
     def testRoundingDec(self):
-
         self.assertEqual(lsstutils.decDegToStr(15.0), "+15:00:00.00")
-        self.assertEqual(lsstutils.decDegToStr(15.00000001), "+15:00:00.00")
         self.assertEqual(lsstutils.decDegToStr(15.00000001), "+15:00:00.00")
 
         self.assertEqual(lsstutils.decDegToStr(14.9999), "+14:59:59.64")
@@ -105,30 +80,16 @@ class RaDecToStrTestCase(lsst.utils.tests.TestCase):
 
     # Testing strings to numbers
 
-    def testRaStrToRad(self):
-        for i in range(self.num):
-            raDeg = self.goodData[i][self.raDegCol]
+    def testStrToRad(self):
+        for raDeg, decDeg, raStr, decStr in self.goodData:
             raRad = raDeg*math.pi/180.
-            raStr = self.goodData[i][self.raStrCol]
+            decRad = decDeg*math.pi/180.
             self.assertAlmostEqual(lsstutils.raStrToRad(raStr), raRad, 6)
+            self.assertAlmostEqual(lsstutils.decStrToRad(decStr), decRad, 6)
 
-    def testRaStrToDeg(self):
-        for i in range(self.num):
-            raDeg = self.goodData[i][self.raDegCol]
-            raStr = self.goodData[i][self.raStrCol]
+    def testStrToDeg(self):
+        for raDeg, decDeg, raStr, decStr in self.goodData:
             self.assertAlmostEqual(lsstutils.raStrToDeg(raStr), raDeg, 4)
-
-    def testDecStrToRad(self):
-        for i in range(self.num):
-            decDeg = self.goodData[i][self.decDegCol]
-            decRad = decDeg*math.pi/180
-            decStr = self.goodData[i][self.decStrCol]
-            self.assertAlmostEqual(lsstutils.decStrToRad(decStr), decRad, 4)
-
-    def testDecStrToDeg(self):
-        for i in range(self.num):
-            decDeg = self.goodData[i][self.decDegCol]
-            decStr = self.goodData[i][self.decStrCol]
             self.assertAlmostEqual(lsstutils.decStrToDeg(decStr), decDeg, 3)
 
 


### PR DESCRIPTION
I added tests that use the delimiters, and fixed/pythonized/deduplicated the code.