### PR TITLE
DM-8605: Remove the log configuration from tests utility initialization

### DIFF
--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -35,7 +35,6 @@ import sys
 import unittest
 import warnings
 import numpy
-import lsst.log
 
 # File descriptor leak test will be skipped if psutil can not be imported
 try:
@@ -66,21 +65,13 @@ def _get_open_files():
 
 
 def init():
-    """Initialize the memory tester and configure a default log."""
+    """Initialize the memory tester"""
     global memId0
     global open_files
     if dafBase:
         memId0 = dafBase.Citizen_getNextMemId()  # used by MemoryTestCase
     # Reset the list of open files
     open_files = _get_open_files()
-    # Setup a default configuration for log used in the test framework
-    lsst.log.configure_prop("""
-log4j.rootLogger=INFO, A1
-log4j.appender.A1=ConsoleAppender
-log4j.appender.A1.Target=System.err
-log4j.appender.A1.layout=PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-5p %c: %m%n
-""")
 
 
 def run(suite, exit=True):

--- a/ups/utils.table
+++ b/ups/utils.table
@@ -1,7 +1,6 @@
 setupRequired(base)
 setupRequired(pex_exceptions)
 setupRequired(boost)
-setupRequired(log)
 setupRequired(numpy)
 setupRequired(python_psutil)
 setupRequired(python_future)


### PR DESCRIPTION
The current default log configuration is already good.