### PR TITLE
DM-8805: utilities for pybind11 wrappers

### DIFF
--- a/include/lsst/utils/pybind11.h
+++ b/include/lsst/utils/pybind11.h
@@ -53,7 +53,7 @@ This is wrapped as follows for `lsst::afw::table::BaseRecord`, where `cls` is an
 
     utils::addSharedPtrEquality<BaseRecord>(cls);
 
-Note that all record sublasses inherit this behavior without needing to call this function.
+Note that all record subclasses inherit this behavior without needing to call this function.
 */
 template<typename T, typename PyClass>
 inline void addSharedPtrEquality(PyClass & cls) {

--- a/python/lsst/utils/__init__.py
+++ b/python/lsst/utils/__init__.py
@@ -24,3 +24,4 @@ from __future__ import absolute_import
 from .utilsLib import *
 from .get_caller_name import *
 from .version import *
+from .wrappers import *

--- a/python/lsst/utils/wrappers.py
+++ b/python/lsst/utils/wrappers.py
@@ -25,12 +25,9 @@ def isAttributeSafeToTransfer(name, value):
     classes, leaving only those explicitly defined in a class decorated by
     `continueClass` or registered with an instance of `TemplateMeta`.
     """
-    if name.startswith("__"):
-        if (value is not getattr(object, name, None) and
-                name not in INTRINSIC_SPECIAL_ATTRIBUTES):
-            return True
-        else:
-            return False
+    if name.startswith("__") and (value is getattr(object, name, None) or
+                                  name in INTRINSIC_SPECIAL_ATTRIBUTES):
+        return False
     return True
 
 
@@ -91,21 +88,297 @@ def inClass(cls, name=None):
     or the ``name`` optional argument is provided.
     """
     def decorate(func):
-        if name is not None:
+        # Using 'name' instead of 'name1' breaks the closure because
+        # assignment signals a strictly local variable.
+        name1 = name
+        if name1 is None:
             if hasattr(func, "__name__"):
-                name = func.__name__
+                name1 = func.__name__
             else:
                 if hasattr(func, "__func__"):
                     # classmethod and staticmethod have __func__ but no __name__
-                    name = func.__func__.__name__
+                    name1 = func.__func__.__name__
                 elif hasattr(func, "fget"):
                     # property has fget but no __name__
-                    name = func.fget.__name__
+                    name1 = func.fget.__name__
                 else:
                     raise ValueError(
                         "Could not guess attribute name for '{}'.".format(func)
                     )
-        setattr(cls, name, func)
+        setattr(cls, name1, func)
         return func
     return decorate
 
+
+class TemplateMeta(type):
+    """A metaclass for abstract base classes that tie together wrapped C++
+    template types.
+
+    C++ template classes are most easily wrapped with a separate Python class
+    for each template type, which results in an unnatural Python interface.
+    TemplateMeta provides a thin layer that connects these Python classes by
+    giving them a common base class and acting as a factory to construct them
+    in a consistent way.
+
+    To use, simply create a new class with the name of the template class, and
+    use ``TemplateMeta`` as its metaclass, and then call ``register`` on each
+    of its subclasses.  This registers the class with a "type key" - usually a
+    Python representation of the C++ template types.  The type key must be a
+    hashable object - strings, type objects, and tuples of these (for C++
+    classes with multiple template parameters) are good choices.  Alternate
+    type keys for existing classes can be added by calling ``alias``, but only
+    after a subclass already been registered with a "primary" type key.  For
+    example (using Python 3 metaclass syntax)::
+
+        import numpy as np
+        from ._image import ImageF, ImageD
+
+        class Image(metaclass=TemplateMeta):
+            pass
+
+        Image.register(np.float32, ImageF)
+        Image.register(np.float64, ImageD)
+        Image.alias("F", ImageF)
+        Image.alias("D", ImageD)
+
+    We have intentionally used ``numpy`` types as the primary keys for these
+    objects in this example, with strings as secondary aliases simply because
+    the primary key is added as a ``dtype`` attribute on the the registered
+    classes (so ``ImageF.dtype == numpy.float32`` in the above example).
+
+    This allows user code to construct objects directly using ``Image``, as
+    long as an extra ``dtype`` keyword argument is passed that matches one of
+    the type keys::
+
+        img = Image(52, 64, dtype=np.float32)
+
+    This simply forwards additional positional and keyword arguments to the
+    wrapped template class's constructor.
+
+    The choice of "dtype" as the name of the template parameter is also
+    configurable, and in fact multiple template parameters are also supported,
+    by setting a ``TEMPLATE_PARAMS`` class attribute on the ABC to a tuple
+    containing the names of the template parameters.  A ``TEMPLATE_DEFAULTS``
+    attribute can also be defined to a tuple of the same length containing
+    default values for the template parameters, allowing them to be omitted in
+    constructor calls.  When the length of these attributes is more than one,
+    the type keys passed to ``register`` and ``alias`` should be tuple of the
+    same length; when the length of these attributes is one, type keys should
+    generally not be tuples.
+
+    As an aid for those writing the Python wrappers for C++ classes,
+    ``TemplateMeta`` also provides a way to add pure-Python methods and other
+    attributes to the wrapped template classes.  To add a ``sum`` method to
+    all registered types, for example, we can just do::
+
+        class Image(metaclass=TemplateMeta):
+
+            def sum(self):
+                return np.sum(self.getArray())
+
+        Image.register(np.float32, ImageF)
+        Image.register(np.float64, ImageD)
+
+    .. note::
+
+        ``TemplateMeta`` works by overriding the ``__instancecheck__`` and
+        ``__subclasscheck__`` special methods, and hence does not appear in
+        its registered subclasses' method resolution order or ``__bases__``
+        attributes. That means its attributes are not inherited by registered
+        subclasses. Instead, attributes added to an instance of
+        ``TemplateMeta`` are *copied* into the types registered with it. These
+        attributes will thus *replace* existing attributes in those classes
+        with the same name, and subclasses cannot delegate to base class
+        implementations of these methods.
+
+    Finally, abstract base classes that use ``TemplateMeta`` define a dict-
+    like interface for accessing their registered subclasses, providing
+    something like the C++ syntax for templates::
+
+        Image[np.float32] -> ImageF
+        Image["D"] -> ImageD
+
+    Both primary dtypes and aliases can be used as keys in this interface,
+    which means types with aliases will be present multiple times in the dict.
+    To obtain the sequence of unique subclasses, use the ``__subclasses__``
+    method.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        # __new__ is invoked when the abstract base class is defined (via a
+        # class statement).  We save a dict of class attributes (including
+        # methods) that were defined in the class body so we can copy them
+        # to registered subclasses later.
+        # We also initialize an empty dict to store the registered subclasses.
+        attrs["_inherited"] = {k: v for k, v in attrs.items()
+                               if isAttributeSafeToTransfer(k, v)}
+        # The special "TEMPLATE_PARAMS" class attribute, if defined, contains
+        # names of the template parameters, which we use to set those
+        # attributes on registered subclasses and intercept arguments to the
+        # constructor.  This line removes it from the dict of things that
+        # should be inherited while setting a default of 'dtype' if it's not
+        # defined.
+        attrs["TEMPLATE_PARAMS"] = \
+            attrs["_inherited"].pop("TEMPLATE_PARAMS", ("dtype",))
+        attrs["TEMPLATE_DEFAULTS"] = \
+            attrs["_inherited"].pop("TEMPLATE_DEFAULTS",
+                                    (None,)*len(attrs["TEMPLATE_PARAMS"]))
+        attrs["_registry"] = dict()
+        self = type.__new__(cls, name, bases, attrs)
+
+        if len(self.TEMPLATE_PARAMS) == 0:
+            raise ValueError(
+                "TEMPLATE_PARAMS must be a tuple with at least one element."
+            )
+        if len(self.TEMPLATE_DEFAULTS) != len(self.TEMPLATE_PARAMS):
+            raise ValueError(
+                "TEMPLATE_PARAMS and TEMPLATE_DEFAULTS must have same length."
+            )
+        return self
+
+    def __call__(self, *args, **kwds):
+        # __call__ is invoked when someone tries to construct an instance of
+        # the abstract base class.
+        # If the ABC defines a "TEMPLATE_PARAMS" attribute, we use those strings
+        # as the kwargs we should intercept to find the right type.
+        key = tuple(kwds.pop(p, d) for p, d in zip(self.TEMPLATE_PARAMS,
+                                                   self.TEMPLATE_DEFAULTS))
+        if len(key) == 1:
+            # indices are only tuples if there are multiple elements
+            key = key[0]
+        cls = self._registry.get(key, None)
+        if cls is None:
+            d = {k: v for k, v in zip(self.TEMPLATE_PARAMS, key)}
+            raise TypeError("No registered subclass for {}.".format(d))
+        return cls(*args, **kwds)
+
+    def __subclasscheck__(self, subclass):
+        # Special method hook for the issubclass built-in: we return true for
+        # any registered type or true subclass thereof.
+        if subclass in self._registry:
+            return True
+        for v in self._registry.values():
+            if issubclass(subclass, v):
+                return True
+        return False
+
+    def __instancecheck__(self, instance):
+        # Special method hook for the isinstance built-in: we return true for
+        # an instance of any registered type or true subclass thereof.
+        if type(instance) in self._registry:
+            return True
+        for v in self._registry.values():
+            if isinstance(instance, v):
+                return True
+        return False
+
+    def __subclasses__(self):
+        """Return a tuple of all classes that inherit from this class.
+        """
+        # This special method isn't defined as part of the Python data model,
+        # but it exists on builtins (including ABCMeta), and it provides useful
+        # functionality.
+        return tuple(set(self._registry.values()))
+
+    def register(self, key, subclass):
+        """Register a subclass of this ABC with the given key (a string,
+        number, type, or other hashable).
+
+        Register may only be called once for a given key or a given subclass.
+        """
+        if key is None:
+            raise ValueError("None may not be used as a key.")
+        if subclass in self._registry.values():
+            raise ValueError(
+                "This subclass has already registered with another key; "
+                "use alias() instead."
+            )
+        if self._registry.setdefault(key, subclass) != subclass:
+            if len(self.TEMPLATE_PARAMS) == 1:
+                d = {self.TEMPLATE_PARAMS[0]: key}
+            else:
+                d = {k: v for k, v in zip(self.TEMPLATE_PARAMS, key)}
+            raise KeyError(
+                "Another subclass is already registered with {}".format(d)
+            )
+
+        def setattrSafe(name, value):
+            try:
+                currentValue = getattr(subclass, name)
+                if currentValue != value:
+                    msg = ("subclass already has a '{}' attribute with "
+                           "value {} != {}.")
+                    raise ValueError(
+                        msg.format(name, currentValue, value)
+                    )
+            except AttributeError:
+                setattr(subclass, name, value)
+
+        if len(self.TEMPLATE_PARAMS) == 1:
+            setattrSafe(self.TEMPLATE_PARAMS[0], key)
+        elif len(self.TEMPLATE_PARAMS) == len(key):
+            for p, k in zip(self.TEMPLATE_PARAMS, key):
+                setattrSafe(p, k)
+        else:
+            raise ValueError(
+                "key must have {} elements (one for each of {})".format(
+                    len(self.TEMPLATE_PARAMS), self.TEMPLATE_PARAMS
+                )
+            )
+
+        for name, attr in self._inherited.items():
+            setattr(subclass, name, attr)
+
+    def alias(self, key, subclass):
+        """Add an alias that allows an existing subclass to be accessed with a
+        different key.
+        """
+        if key is None:
+            raise ValueError("None may not be used as a key.")
+        if key in self._registry:
+            raise KeyError("Cannot multiply-register key {}".format(key))
+        primaryKey = tuple(getattr(subclass, p, None)
+                           for p in self.TEMPLATE_PARAMS)
+        if len(primaryKey) == 1:
+            # indices are only tuples if there are multiple elements
+            primaryKey = primaryKey[0]
+        if self._registry.get(primaryKey, None) != subclass:
+            raise ValueError("Subclass is not registered with this base class.")
+        self._registry[key] = subclass
+
+    # Immutable mapping interface defined below.  We don't use collections
+    # mixins because we don't want their comparison operators.
+
+    def __getitem__(self, key):
+        return self._registry[key]
+
+    def __iter__(self):
+        return iter(self._registry)
+
+    def __len__(self):
+        return len(self._registry)
+
+    def __contains__(self, key):
+        return key in self._registry
+
+    def keys(self):
+        """Return an iterable containing all keys (including aliases).
+        """
+        return self._registry.keys()
+
+    def values(self):
+        """Return an iterable of registered subclasses, with duplicates
+        corresponding to any aliases.
+        """
+        return self._registry.values()
+
+    def items(self):
+        """Return an iterable of (key, subclass) pairs.
+        """
+        return self._registry.items()
+
+    def get(self, key, default=None):
+        """Return the subclass associated with the given key (including
+        aliases), or ``default`` if the key is not recognized.
+        """
+        return self._registry.get(key, default)

--- a/python/lsst/utils/wrappers.py
+++ b/python/lsst/utils/wrappers.py
@@ -66,3 +66,46 @@ def continueClass(cls):
             setattr(orig, name, attr)
     return orig
 
+
+def inClass(cls, name=None):
+    """Add the decorated function to the given class as a method.
+
+    For example,
+    ::
+        class Foo:
+            pass
+
+        @inClass(Foo)
+        def run(self):
+            return None
+
+    is equivalent to::
+
+        class Foo:
+            def run(self):
+                return None
+
+    Standard decorators like ``classmethod``, ``staticmethod``, and
+    ``property`` may be used *after* this decorator.  Custom decorators
+    may only be used if they return an object with a ``__name__`` attribute
+    or the ``name`` optional argument is provided.
+    """
+    def decorate(func):
+        if name is not None:
+            if hasattr(func, "__name__"):
+                name = func.__name__
+            else:
+                if hasattr(func, "__func__"):
+                    # classmethod and staticmethod have __func__ but no __name__
+                    name = func.__func__.__name__
+                elif hasattr(func, "fget"):
+                    # property has fget but no __name__
+                    name = func.fget.__name__
+                else:
+                    raise ValueError(
+                        "Could not guess attribute name for '{}'.".format(func)
+                    )
+        setattr(cls, name, func)
+        return func
+    return decorate
+

--- a/python/lsst/utils/wrappers.py
+++ b/python/lsst/utils/wrappers.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+__all__ = ("continueClass", "inClass", "TemplateMeta")
+
+
+INTRINSIC_SPECIAL_ATTRIBUTES = frozenset((
+    "__qualname__",
+    "__module__",
+    "__metaclass__",
+    "__dict__",
+    "__weakref__",
+    "__class__",
+    "__subclasshook__",
+    "__name__",
+))
+
+
+def isAttributeSafeToTransfer(name, value):
+    """Return True if an attribute is safe to monkeypatch-transfer to another
+    class.
+
+    This rejects special methods that are defined automatically for all
+    classes, leaving only those explicitly defined in a class decorated by
+    `continueClass` or registered with an instance of `TemplateMeta`.
+    """
+    if name.startswith("__"):
+        if (value is not getattr(object, name, None) and
+                name not in INTRINSIC_SPECIAL_ATTRIBUTES):
+            return True
+        else:
+            return False
+    return True
+
+
+def continueClass(cls):
+    """Re-open the decorated class, adding any new definitions into the original.
+
+    For example,
+    ::
+        class Foo:
+            pass
+
+        @continueClass
+        class Foo:
+            def run(self):
+                return None
+
+    is equivalent to
+    ::
+        class Foo:
+            def run(self):
+                return None
+
+    """
+    orig = getattr(sys.modules[cls.__module__], cls.__name__)
+    for name in dir(cls):
+        # Common descriptors like classmethod and staticmethod can only be
+        # accessed without invoking their magic if we use __dict__; if we use
+        # getattr on those we'll get e.g. a bound method instance on the dummy
+        # class rather than a classmethod instance we can put on the target
+        # class.
+        attr = cls.__dict__.get(name, None) or getattr(cls, name)
+        if isAttributeSafeToTransfer(name, attr):
+            setattr(orig, name, attr)
+    return orig
+

--- a/tests/testWrappers.py
+++ b/tests/testWrappers.py
@@ -5,6 +5,7 @@ from future.utils import with_metaclass
 import numpy as np
 import unittest
 import lsst.utils.tests
+import lsst.utils
 
 
 class MockClass:   # continued class needs to be at module scope
@@ -87,11 +88,14 @@ class DecoratorsTestCase(lsst.utils.tests.TestCase):
         self.assertFalse(x.property1b)
 
 
-class TemplateMetaTestCase(lsst.utils.tests.TestCase):
+class TemplateMetaSimpleTestCase(lsst.utils.tests.TestCase):
+    """Test TemplateMeta on a mockup of a template with a single dtype
+    template parameter.
+    """
 
     def setUp(self):
 
-        class Base(with_metaclass(lsst.utils.TemplateMeta, object)):
+        class Example(with_metaclass(lsst.utils.TemplateMeta, object)):
 
             def method1(self):
                 return self
@@ -108,97 +112,103 @@ class TemplateMetaTestCase(lsst.utils.tests.TestCase):
             def property1(self):
                 return False
 
-        class DerivedF:
+        class ExampleF:
             pass
 
-        class DerivedD:
+        class ExampleD:
             pass
 
-        self.Base = Base
-        self.DerivedF = DerivedF
-        self.DerivedD = DerivedD
+        self.Example = Example
+        self.ExampleF = ExampleF
+        self.ExampleD = ExampleD
 
     def register(self):
-        self.Base.register(np.float32, self.DerivedF)
-        self.Base.register(np.float64, self.DerivedD)
+        self.Example.register(np.float32, self.ExampleF)
+        self.Example.register(np.float64, self.ExampleD)
 
     def alias(self):
-        self.Base.alias("F", self.DerivedF)
-        self.Base.alias("D", self.DerivedD)
+        self.Example.alias("F", self.ExampleF)
+        self.Example.alias("D", self.ExampleD)
 
     def testCorrectRegistration(self):
         self.register()
-        self.assertEqual(self.DerivedF.dtype, np.float32)
-        self.assertEqual(self.DerivedD.dtype, np.float64)
-        self.assertIn(np.float32, self.Base)
-        self.assertIn(np.float64, self.Base)
-        self.assertEqual(self.Base[np.float32], self.DerivedF)
-        self.assertEqual(self.Base[np.float64], self.DerivedD)
+        self.assertEqual(self.ExampleF.dtype, np.float32)
+        self.assertEqual(self.ExampleD.dtype, np.float64)
+        self.assertIn(np.float32, self.Example)
+        self.assertIn(np.float64, self.Example)
+        self.assertEqual(self.Example[np.float32], self.ExampleF)
+        self.assertEqual(self.Example[np.float64], self.ExampleD)
 
     def testAliases(self):
         self.register()
         self.alias()
-        self.assertEqual(self.DerivedF.dtype, np.float32)
-        self.assertEqual(self.DerivedD.dtype, np.float64)
-        self.assertIn("F", self.Base)
-        self.assertIn("D", self.Base)
-        self.assertEqual(self.Base["F"], self.DerivedF)
-        self.assertEqual(self.Base["D"], self.DerivedD)
+        self.assertEqual(self.ExampleF.dtype, np.float32)
+        self.assertEqual(self.ExampleD.dtype, np.float64)
+        self.assertIn("F", self.Example)
+        self.assertIn("D", self.Example)
+        self.assertEqual(self.Example["F"], self.ExampleF)
+        self.assertEqual(self.Example["D"], self.ExampleD)
+        self.assertEqual(self.Example["F"], self.Example[np.float32])
+        self.assertEqual(self.Example["D"], self.Example[np.float64])
 
     def testInheritanceHooks(self):
         self.register()
-        self.assertTrue(issubclass(self.DerivedF, self.Base))
-        self.assertTrue(issubclass(self.DerivedD, self.Base))
-        f = self.DerivedF()
-        d = self.DerivedD()
-        self.assertIsInstance(f, self.Base)
-        self.assertIsInstance(d, self.Base)
-        self.assertEqual(set(self.Base.__subclasses__()), set([self.DerivedF, self.DerivedD]))
+        self.assertTrue(issubclass(self.ExampleF, self.Example))
+        self.assertTrue(issubclass(self.ExampleD, self.Example))
+        f = self.ExampleF()
+        d = self.ExampleD()
+        self.assertIsInstance(f, self.Example)
+        self.assertIsInstance(d, self.Example)
+        self.assertEqual(set(self.Example.__subclasses__()), set([self.ExampleF, self.ExampleD]))
 
     def testConstruction(self):
         self.register()
-        f = self.Base(dtype=np.float32)
-        self.assertIsInstance(f, self.Base)
-        self.assertIsInstance(f, self.DerivedF)
+        f = self.Example(dtype=np.float32)
+        self.assertIsInstance(f, self.Example)
+        self.assertIsInstance(f, self.ExampleF)
+        self.assertNotIsInstance(f, self.ExampleD)
         with self.assertRaises(TypeError):
-            self.Base()
+            self.Example()
         with self.assertRaises(TypeError):
-            self.Base(dtype=np.int32)
+            self.Example(dtype=np.int32)
 
     def testAttributeCopying(self):
         self.register()
-        f = self.DerivedF()
-        d = self.DerivedD()
+        f = self.ExampleF()
+        d = self.ExampleD()
         self.assertIs(f.method1(), f)
         self.assertIs(d.method1(), d)
-        self.assertIs(f.method2(), self.DerivedF)
-        self.assertIs(d.method2(), self.DerivedD)
-        self.assertIs(self.DerivedF.method2(), self.DerivedF)
-        self.assertIs(self.DerivedD.method2(), self.DerivedD)
+        self.assertIs(f.method2(), self.ExampleF)
+        self.assertIs(d.method2(), self.ExampleD)
+        self.assertIs(self.ExampleF.method2(), self.ExampleF)
+        self.assertIs(self.ExampleD.method2(), self.ExampleD)
         self.assertTrue(f.method3())
         self.assertTrue(d.method3())
-        self.assertTrue(self.DerivedF.method3())
-        self.assertTrue(self.DerivedD.method3())
+        self.assertTrue(self.ExampleF.method3())
+        self.assertTrue(self.ExampleD.method3())
         self.assertFalse(f.property1)
         self.assertFalse(d.property1)
 
     def testDictBehavior(self):
         self.register()
-        self.assertIn(np.float32, self.Base)
-        self.assertEqual(self.Base[np.float32], self.DerivedF)
-        self.assertEqual(set(self.Base.keys()), set([np.float32, np.float64]))
-        self.assertEqual(set(self.Base.values()), set([self.DerivedF, self.DerivedD]))
-        self.assertEqual(set(self.Base.items()), set([(np.float32, self.DerivedF),
-                                                      (np.float64, self.DerivedD)]))
-        self.assertEqual(len(self.Base), 2)
-        self.assertEqual(set(iter(self.Base)), set([np.float32, np.float64]))
-        self.assertEqual(self.Base.get(np.float64), self.DerivedD)
-        self.assertEqual(self.Base.get(np.int32, False), False)
+        self.assertIn(np.float32, self.Example)
+        self.assertEqual(self.Example[np.float32], self.ExampleF)
+        self.assertEqual(set(self.Example.keys()),
+                         set([np.float32, np.float64]))
+        self.assertEqual(set(self.Example.values()),
+                         set([self.ExampleF, self.ExampleD]))
+        self.assertEqual(set(self.Example.items()),
+                         set([(np.float32, self.ExampleF),
+                              (np.float64, self.ExampleD)]))
+        self.assertEqual(len(self.Example), 2)
+        self.assertEqual(set(iter(self.Example)), set([np.float32, np.float64]))
+        self.assertEqual(self.Example.get(np.float64), self.ExampleD)
+        self.assertEqual(self.Example.get(np.int32, False), False)
 
     def testNoInheritedDictBehavior(self):
         self.register()
-        f = self.DerivedF()
-        with self.assertRaises(TypeError):
+        f = self.ExampleF()
+        with self.assertRaises(Exception): # Py2:AttributeError, Py3:TypeError
             len(f)
         with self.assertRaises(TypeError):
             f["F"]
@@ -206,34 +216,172 @@ class TemplateMetaTestCase(lsst.utils.tests.TestCase):
             for x in f:
                 pass
         with self.assertRaises(TypeError):
-            len(self.DerivedF)
+            len(self.ExampleF)
         with self.assertRaises(TypeError):
-            self.DerivedF["F"]
+            self.ExampleF["F"]
         with self.assertRaises(TypeError):
-            for x in self.DerivedF:
+            for x in self.ExampleF:
                 pass
 
     def testAliasUnregistered(self):
         with self.assertRaises(ValueError):
-            self.Base.alias("F", self.DerivedF)
-        self.assertEqual(len(self.Base), 0)
-        with self.assertRaises(ValueError):
-            self.DerivedF.dtype = "D"
-            self.Base.alias("F", self.DerivedF)
-        self.assertEqual(len(self.Base), 0)
+            self.Example.alias("F", self.ExampleF)
+        self.assertEqual(len(self.Example), 0)
+        self.assertEqual(len(self.Example), 0)
 
     def testRegisterDTypeTwice(self):
         with self.assertRaises(KeyError):
-            self.Base.register("F", self.DerivedF)
-            self.Base.register("F", self.DerivedD)
-        self.assertEqual(len(self.Base), 1)
+            self.Example.register("F", self.ExampleF)
+            self.Example.register("F", self.ExampleD)
+        self.assertEqual(len(self.Example), 1)
 
     def testRegisterTemplateTwice(self):
         with self.assertRaises(ValueError):
-            self.Base.register("F", self.DerivedF)
-            self.Base.register("D", self.DerivedF)
-        self.assertEqual(len(self.Base), 1)
+            self.Example.register("F", self.ExampleF)
+            self.Example.register("D", self.ExampleF)
+        self.assertEqual(len(self.Example), 1)
 
+
+class TemplateMetaHardTestCase(lsst.utils.tests.TestCase):
+    """Test TemplateMeta with a mockup of a template with multiple
+    template parameters.
+    """
+
+    def setUp(self):
+
+        class Example(with_metaclass(lsst.utils.TemplateMeta, object)):
+
+            TEMPLATE_PARAMS = ("d", "u")
+            TEMPLATE_DEFAULTS = (2, None)
+
+        class Example2F:
+            pass
+
+        class Example2D:
+            pass
+
+        class Example3F:
+            pass
+
+        class Example3D:
+            pass
+
+        self.Example = Example
+        self.Example2F = Example2F
+        self.Example2D = Example2D
+        self.Example3F = Example3F
+        self.Example3D = Example3D
+
+    def register(self):
+        self.Example.register((2, np.float32), self.Example2F)
+        self.Example.register((2, np.float64), self.Example2D)
+        self.Example.register((3, np.float32), self.Example3F)
+        self.Example.register((3, np.float64), self.Example3D)
+
+    def alias(self):
+        self.Example.alias("2F", self.Example2F)
+        self.Example.alias("2D", self.Example2D)
+        self.Example.alias("3F", self.Example3F)
+        self.Example.alias("3D", self.Example3D)
+
+    def testCorrectRegistration(self):
+        self.register()
+        self.assertEqual(self.Example2F.d, 2)
+        self.assertEqual(self.Example2F.u, np.float32)
+        self.assertEqual(self.Example2D.d, 2)
+        self.assertEqual(self.Example2D.u, np.float64)
+        self.assertEqual(self.Example3F.d, 3)
+        self.assertEqual(self.Example3F.u, np.float32)
+        self.assertEqual(self.Example3D.d, 3)
+        self.assertEqual(self.Example3D.u, np.float64)
+        self.assertIn((2, np.float32), self.Example)
+        self.assertIn((2, np.float64), self.Example)
+        self.assertIn((3, np.float32), self.Example)
+        self.assertIn((3, np.float64), self.Example)
+        self.assertEqual(self.Example[2, np.float32], self.Example2F)
+        self.assertEqual(self.Example[2, np.float64], self.Example2D)
+        self.assertEqual(self.Example[3, np.float32], self.Example3F)
+        self.assertEqual(self.Example[3, np.float64], self.Example3D)
+
+    def testAliases(self):
+        self.register()
+        self.alias()
+        self.assertEqual(self.Example2F.d, 2)
+        self.assertEqual(self.Example2F.u, np.float32)
+        self.assertEqual(self.Example2D.d, 2)
+        self.assertEqual(self.Example2D.u, np.float64)
+        self.assertEqual(self.Example3F.d, 3)
+        self.assertEqual(self.Example3F.u, np.float32)
+        self.assertEqual(self.Example3D.d, 3)
+        self.assertEqual(self.Example3D.u, np.float64)
+        self.assertIn("2F", self.Example)
+        self.assertIn("2D", self.Example)
+        self.assertIn("3F", self.Example)
+        self.assertIn("3D", self.Example)
+        self.assertEqual(self.Example["2F"], self.Example2F)
+        self.assertEqual(self.Example["2D"], self.Example2D)
+        self.assertEqual(self.Example["3F"], self.Example3F)
+        self.assertEqual(self.Example["3D"], self.Example3D)
+
+    def testInheritanceHooks(self):
+        self.register()
+        self.assertTrue(issubclass(self.Example2F, self.Example))
+        self.assertTrue(issubclass(self.Example3D, self.Example))
+        f = self.Example2F()
+        d = self.Example3D()
+        self.assertIsInstance(f, self.Example)
+        self.assertIsInstance(d, self.Example)
+        self.assertEqual(set(self.Example.__subclasses__()),
+                         set([self.Example2F, self.Example2D,
+                              self.Example3F, self.Example3D]))
+
+    def testConstruction(self):
+        self.register()
+        f = self.Example(u=np.float32)
+        self.assertIsInstance(f, self.Example)
+        self.assertIsInstance(f, self.Example2F)
+        with self.assertRaises(TypeError):
+            self.Example()
+        with self.assertRaises(TypeError):
+            self.Example(u=np.int32, d=1)
+
+    def testDictBehavior(self):
+        self.register()
+        self.assertIn((2, np.float32), self.Example)
+        self.assertEqual(self.Example[2, np.float32], self.Example2F)
+        self.assertEqual(set(self.Example.keys()),
+                         set([(2, np.float32), (2, np.float64),
+                              (3, np.float32), (3, np.float64)]))
+        self.assertEqual(set(self.Example.values()),
+                         set([self.Example2F, self.Example2D,
+                              self.Example3F, self.Example3D]))
+        self.assertEqual(set(self.Example.items()),
+                         set([((2, np.float32), self.Example2F),
+                              ((2, np.float64), self.Example2D),
+                              ((3, np.float32), self.Example3F),
+                              ((3, np.float64), self.Example3D)]))
+        self.assertEqual(len(self.Example), 4)
+        self.assertEqual(set(iter(self.Example)),
+                         set([(2, np.float32), (2, np.float64),
+                              (3, np.float32), (3, np.float64)]))
+        self.assertEqual(self.Example.get((3, np.float64)), self.Example3D)
+        self.assertEqual(self.Example.get((2, np.int32), False), False)
+
+    def testRegisterBadKey(self):
+        with self.assertRaises(ValueError):
+            self.Example.register("F", self.Example2F)
+
+    def testRegisterDTypeTwice(self):
+        with self.assertRaises(KeyError):
+            self.Example.register((2, "F"), self.Example2F)
+            self.Example.register((2, "F"), self.Example2D)
+        self.assertEqual(len(self.Example), 1)
+
+    def testRegisterTemplateTwice(self):
+        with self.assertRaises(ValueError):
+            self.Example.register((2, "F"), self.Example2F)
+            self.Example.register((2, "D"), self.Example2F)
+        self.assertEqual(len(self.Example), 1)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testWrappers.py
+++ b/tests/testWrappers.py
@@ -7,6 +7,86 @@ import unittest
 import lsst.utils.tests
 
 
+class MockClass:   # continued class needs to be at module scope
+
+    def method1(self):
+        return self
+
+    @classmethod
+    def method2(cls):
+        return cls
+
+    @staticmethod
+    def method3():
+        return True
+
+    @property
+    def property1(self):
+        return False
+
+
+class DecoratorsTestCase(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+        @lsst.utils.continueClass
+        class MockClass:
+
+            def method1a(self):
+                return self
+
+            @classmethod
+            def method2a(cls):
+                return cls
+
+            @staticmethod
+            def method3a():
+                return True
+
+            @property
+            def property1a(self):
+                return False
+
+        @lsst.utils.inClass(MockClass)
+        def method1b(self):
+            return self
+
+        @lsst.utils.inClass(MockClass)
+        @classmethod
+        def method2b(cls):
+            return cls
+
+        @lsst.utils.inClass(MockClass)
+        @staticmethod
+        def method3b():
+            return True
+
+        @lsst.utils.inClass(MockClass)
+        @property
+        def property1b(self):
+            return False
+
+    def testAttributeCopying(self):
+        x = MockClass()
+        self.assertIs(x.method1(), x)
+        self.assertIs(x.method1a(), x)
+        self.assertIs(x.method1b(), x)
+        self.assertIs(x.method2(), MockClass)
+        self.assertIs(x.method2a(), MockClass)
+        self.assertIs(x.method2b(), MockClass)
+        self.assertIs(MockClass.method2(), MockClass)
+        self.assertIs(MockClass.method2a(), MockClass)
+        self.assertIs(MockClass.method2b(), MockClass)
+        self.assertTrue(x.method3())
+        self.assertTrue(x.method3a())
+        self.assertTrue(x.method3b())
+        self.assertTrue(MockClass.method3())
+        self.assertTrue(MockClass.method3a())
+        self.assertTrue(MockClass.method3b())
+        self.assertFalse(x.property1)
+        self.assertFalse(x.property1a)
+        self.assertFalse(x.property1b)
+
+
 class TemplateMetaTestCase(lsst.utils.tests.TestCase):
 
     def setUp(self):

--- a/tests/testWrappers.py
+++ b/tests/testWrappers.py
@@ -1,0 +1,159 @@
+from __future__ import absolute_import, division, print_function
+
+from future.utils import with_metaclass
+
+import numpy as np
+import unittest
+import lsst.utils.tests
+
+
+class TemplateMetaTestCase(lsst.utils.tests.TestCase):
+
+    def setUp(self):
+
+        class Base(with_metaclass(lsst.utils.TemplateMeta, object)):
+
+            def method1(self):
+                return self
+
+            @classmethod
+            def method2(cls):
+                return cls
+
+            @staticmethod
+            def method3():
+                return True
+
+            @property
+            def property1(self):
+                return False
+
+        class DerivedF:
+            pass
+
+        class DerivedD:
+            pass
+
+        self.Base = Base
+        self.DerivedF = DerivedF
+        self.DerivedD = DerivedD
+
+    def register(self):
+        self.Base.register(np.float32, self.DerivedF)
+        self.Base.register(np.float64, self.DerivedD)
+
+    def alias(self):
+        self.Base.alias("F", self.DerivedF)
+        self.Base.alias("D", self.DerivedD)
+
+    def testCorrectRegistration(self):
+        self.register()
+        self.assertEqual(self.DerivedF.dtype, np.float32)
+        self.assertEqual(self.DerivedD.dtype, np.float64)
+        self.assertIn(np.float32, self.Base)
+        self.assertIn(np.float64, self.Base)
+        self.assertEqual(self.Base[np.float32], self.DerivedF)
+        self.assertEqual(self.Base[np.float64], self.DerivedD)
+
+    def testAliases(self):
+        self.register()
+        self.alias()
+        self.assertEqual(self.DerivedF.dtype, np.float32)
+        self.assertEqual(self.DerivedD.dtype, np.float64)
+        self.assertIn("F", self.Base)
+        self.assertIn("D", self.Base)
+        self.assertEqual(self.Base["F"], self.DerivedF)
+        self.assertEqual(self.Base["D"], self.DerivedD)
+
+    def testInheritanceHooks(self):
+        self.register()
+        self.assertTrue(issubclass(self.DerivedF, self.Base))
+        self.assertTrue(issubclass(self.DerivedD, self.Base))
+        f = self.DerivedF()
+        d = self.DerivedD()
+        self.assertIsInstance(f, self.Base)
+        self.assertIsInstance(d, self.Base)
+        self.assertEqual(set(self.Base.__subclasses__()), set([self.DerivedF, self.DerivedD]))
+
+    def testConstruction(self):
+        self.register()
+        f = self.Base(dtype=np.float32)
+        self.assertIsInstance(f, self.Base)
+        self.assertIsInstance(f, self.DerivedF)
+        with self.assertRaises(TypeError):
+            self.Base()
+        with self.assertRaises(TypeError):
+            self.Base(dtype=np.int32)
+
+    def testAttributeCopying(self):
+        self.register()
+        f = self.DerivedF()
+        d = self.DerivedD()
+        self.assertIs(f.method1(), f)
+        self.assertIs(d.method1(), d)
+        self.assertIs(f.method2(), self.DerivedF)
+        self.assertIs(d.method2(), self.DerivedD)
+        self.assertIs(self.DerivedF.method2(), self.DerivedF)
+        self.assertIs(self.DerivedD.method2(), self.DerivedD)
+        self.assertTrue(f.method3())
+        self.assertTrue(d.method3())
+        self.assertTrue(self.DerivedF.method3())
+        self.assertTrue(self.DerivedD.method3())
+        self.assertFalse(f.property1)
+        self.assertFalse(d.property1)
+
+    def testDictBehavior(self):
+        self.register()
+        self.assertIn(np.float32, self.Base)
+        self.assertEqual(self.Base[np.float32], self.DerivedF)
+        self.assertEqual(set(self.Base.keys()), set([np.float32, np.float64]))
+        self.assertEqual(set(self.Base.values()), set([self.DerivedF, self.DerivedD]))
+        self.assertEqual(set(self.Base.items()), set([(np.float32, self.DerivedF),
+                                                      (np.float64, self.DerivedD)]))
+        self.assertEqual(len(self.Base), 2)
+        self.assertEqual(set(iter(self.Base)), set([np.float32, np.float64]))
+        self.assertEqual(self.Base.get(np.float64), self.DerivedD)
+        self.assertEqual(self.Base.get(np.int32, False), False)
+
+    def testNoInheritedDictBehavior(self):
+        self.register()
+        f = self.DerivedF()
+        with self.assertRaises(TypeError):
+            len(f)
+        with self.assertRaises(TypeError):
+            f["F"]
+        with self.assertRaises(TypeError):
+            for x in f:
+                pass
+        with self.assertRaises(TypeError):
+            len(self.DerivedF)
+        with self.assertRaises(TypeError):
+            self.DerivedF["F"]
+        with self.assertRaises(TypeError):
+            for x in self.DerivedF:
+                pass
+
+    def testAliasUnregistered(self):
+        with self.assertRaises(ValueError):
+            self.Base.alias("F", self.DerivedF)
+        self.assertEqual(len(self.Base), 0)
+        with self.assertRaises(ValueError):
+            self.DerivedF.dtype = "D"
+            self.Base.alias("F", self.DerivedF)
+        self.assertEqual(len(self.Base), 0)
+
+    def testRegisterDTypeTwice(self):
+        with self.assertRaises(KeyError):
+            self.Base.register("F", self.DerivedF)
+            self.Base.register("F", self.DerivedD)
+        self.assertEqual(len(self.Base), 1)
+
+    def testRegisterTemplateTwice(self):
+        with self.assertRaises(ValueError):
+            self.Base.register("F", self.DerivedF)
+            self.Base.register("D", self.DerivedF)
+        self.assertEqual(len(self.Base), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This branch adds two major pieces of utility code to aid in wrapping C++ code in downstream packages:
 - a pair of decorators for adding new attributes to existing (presumably wrapped classes)
 - a metaclass in the spirit of `collections.ABCMeta` that helps to tie together different instantiations of the same wrapped template.

While the former is really just about code readability for supplemental wrapper code, the latter provides new more Python (and backwards compatible) interfaces for the classes wrapped with it.