### PR TITLE
ignore astropy.log when testing file descriptor leaks

### DIFF
--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -170,7 +170,8 @@ class MemoryTestCase(unittest.TestCase):
         # Some files are opened out of the control of the stack.
         now_open = set(f for f in now_open if not f.endswith(".car") and
                        not f.endswith(".ttf") and
-                       f != "/var/lib/sss/mc/passwd")
+                       f != "/var/lib/sss/mc/passwd" and
+                       not f.endswith("astropy.log"))
 
         diff = now_open.difference(open_files)
         if diff:


### PR DESCRIPTION
Some users of LSST Simulations packages have been seeing testFileDescriptorLeaks() failures because they have configured astropy to log error messages, warnings etc. to an astropy.log file, which is still open at the point where testFileDescriptorLeaks() runs.  This PR adds astropy.log to the set of files ignored by testFileDescriptorLeaks().