### PR TITLE
DM-10448: Rewrap to 79 characters

### DIFF
--- a/python/lsst/utils/__init__.py
+++ b/python/lsst/utils/__init__.py
@@ -1,4 +1,4 @@
-# 
+#
 # LSST Data Management System
 #
 # Copyright 2008-2017  AURA/LSST.

--- a/python/lsst/utils/get_caller_name.py
+++ b/python/lsst/utils/get_caller_name.py
@@ -29,9 +29,10 @@ __all__ = ["get_caller_name"]
 def get_caller_name(skip=2):
     """Get the name of the caller as a string in the form module.class.method
 
-    Any item that cannot be determined (or is not relevant, e.g. a free function
-    function has no class) is silently omitted, along with an associated separator.
-    An empty string is returned if `skip` exceeds the stack height.
+    Any item that cannot be determined (or is not relevant, e.g. a free
+    function function has no class) is silently omitted, along with an
+    associated separator. An empty string is returned if `skip` exceeds the
+    stack height.
 
     Parameters
     ----------

--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -51,8 +51,10 @@ except ImportError:
 try:
     type(memId0)
 except NameError:
-    memId0 = 0                          # ignore leaked blocks with IDs before memId0
-    nleakPrintMax = 20                  # maximum number of leaked blocks to print
+    # ignore leaked blocks with IDs before memId0
+    memId0 = 0
+    # maximum number of leaked blocks to print
+    nleakPrintMax = 20
 
 # Initialize the list of open files to an empty set
 open_files = set()
@@ -76,7 +78,8 @@ def init():
 
 
 def run(suite, exit=True):
-    """!Exit with the status code resulting from running the provided test suite"""
+    """!Exit with the status code resulting from running the provided test
+    suite"""
 
     if unittest.TextTestRunner().run(suite).wasSuccessful():
         status = 0
@@ -90,8 +93,8 @@ def run(suite, exit=True):
 
 
 def sort_tests(tests):
-    """!Go through the supplied sequence of test suites and sort them to ensure that
-    MemoryTestCases are at the end of the test list. Returns a combined
+    """!Go through the supplied sequence of test suites and sort them to ensure
+    that MemoryTestCases are at the end of the test list. Returns a combined
     TestSuite."""
 
     suite = unittest.TestSuite()
@@ -162,7 +165,8 @@ class MemoryTestCase(unittest.TestCase):
 
     def testFileDescriptorLeaks(self):
         if psutil is None:
-            self.skipTest("Unable to test file descriptor leaks. psutil unavailable.")
+            self.skipTest(
+                "Unable to test file descriptor leaks. psutil unavailable.")
         gc.collect()
         global open_files
         now_open = _get_open_files()
@@ -177,7 +181,8 @@ class MemoryTestCase(unittest.TestCase):
         if diff:
             for f in diff:
                 print("File open: %s" % f)
-            self.fail("Failed to close %d file%s" % (len(diff), "s" if len(diff) != 1 else ""))
+            self.fail("Failed to close %d file%s" %
+                      (len(diff), "s" if len(diff) != 1 else ""))
 
 
 class ExecutablesTestCase(unittest.TestCase):
@@ -233,13 +238,15 @@ class ExecutablesTestCase(unittest.TestCase):
 
         print("Running executable '{}' with {}...".format(executable, argstr))
         if not os.path.exists(executable):
-            self.skipTest("Executable {} is unexpectedly missing".format(executable))
+            self.skipTest(
+                "Executable {} is unexpectedly missing".format(executable))
         failmsg = None
         try:
             output = subprocess.check_output(sp_args)
         except subprocess.CalledProcessError as e:
             output = e.output
-            failmsg = "Bad exit status from '{}': {}".format(executable, e.returncode)
+            failmsg = "Bad exit status from '{}': {}".format(
+                executable, e.returncode)
         print(output.decode('utf-8'))
         if failmsg:
             if msg is None:
@@ -259,7 +266,8 @@ class ExecutablesTestCase(unittest.TestCase):
 
         @param executable Name of executable. Can be absolute path.
 
-        @param root_dir Path to executable. Not used if executable path is absolute.
+        @param root_dir Path to executable. Not used if executable path is
+        absolute.
         """
         if not os.path.isabs(executable):
             executable = os.path.abspath(os.path.join(root_dir, executable))
@@ -326,9 +334,11 @@ class ExecutablesTestCase(unittest.TestCase):
 
 def findFileFromRoot(ifile):
     """!Find file which is specified as a path relative to the toplevel directory;
-    we start in $cwd and walk up until we find the file (or throw IOError if it doesn't exist)
+    we start in $cwd and walk up until we find the file (or throw IOError if it
+    doesn't exist)
 
-    This is useful for running tests that may be run from _dir_/tests or _dir_"""
+    This is useful for running tests that may be run from _dir_/tests or
+    _dir_"""
 
     if os.path.isfile(ifile):
         return ifile
@@ -352,15 +362,18 @@ def findFileFromRoot(ifile):
 
 @contextmanager
 def getTempFilePath(ext):
-    """!Return a path suitable for a temporary file and try to delete the file on success
+    """!Return a path suitable for a temporary file and try to delete the file
+    on success
 
-    If the with block completes successfully then the file is deleted, if possible;
-    failure results in a printed warning.
-    If the block exits with an exception the file if left on disk so it can be examined.
+    If the with block completes successfully then the file is deleted, if
+    possible; failure results in a printed warning.
+    If the block exits with an exception the file if left on disk so it can be
+    examined.
 
     @param[in] ext  file name extension, e.g. ".fits"
-    @return path for a temporary file. The path is a combination of the caller's file path
-    and the name of the top-level function, as per this simple example:
+    @return path for a temporary file. The path is a combination of the
+    caller's file path and the name of the top-level function, as per this
+    simple example:
     @code
     # file tests/testFoo.py
     import unittest
@@ -371,11 +384,13 @@ def getTempFilePath(ext):
 
         def runTest(self):
             with lsst.utils.tests.getTempFilePath(".fits") as tmpFile:
-                # if tests/.tests exists then tmpFile = "tests/.tests/testFoo_testBasics.fits"
+                # if tests/.tests exists then
+                # tmpFile = "tests/.tests/testFoo_testBasics.fits"
                 # otherwise tmpFile = "testFoo_testBasics.fits"
                 ...
-                # at the end of this "with" block the path tmpFile will be deleted, but only if
-                # the file exists and the "with" block terminated normally (rather than with an exception)
+                # at the end of this "with" block the path tmpFile will be
+                # deleted, but only if the file exists and the "with" block
+                # terminated normally (rather than with an exception)
     ...
     @endcode
     """
@@ -425,7 +440,8 @@ def inTestCase(func):
 
 @inTestCase
 def assertRaisesLsstCpp(testcase, excClass, callableObj, *args, **kwargs):
-    warnings.warn("assertRaisesLsstCpp is deprecated; please just use TestCase.assertRaises",
+    warnings.warn("assertRaisesLsstCpp is deprecated;"
+                  " please just use TestCase.assertRaises",
                   DeprecationWarning)
     return testcase.assertRaises(excClass, callableObj, *args, **kwargs)
 
@@ -436,8 +452,10 @@ def debugger(*exceptions):
     To use, just slap a "@debugger()" on your function.
 
     You may provide specific exception classes to catch as arguments to
-    the decorator function, e.g., "@debugger(RuntimeError, NotImplementedError)".
-    This defaults to just 'AssertionError', for use on unittest.TestCase methods.
+    the decorator function,
+    e.g., "@debugger(RuntimeError, NotImplementedError)".
+    This defaults to just 'AssertionError', for use
+    on unittest.TestCase methods.
 
     Code provided by "Rosh Oxymoron" on StackOverflow:
     http://stackoverflow.com/questions/4398967/python-unit-testing-automatically-running-the-debugger-when-a-test-fails
@@ -467,10 +485,12 @@ def plotImageDiff(lhs, rhs, bad=None, diff=None, plotFileName=None):
 
     @param[in]  lhs            LHS values to compare; a 2-d NumPy array
     @param[in]  rhs            RHS values to compare; a 2-d NumPy array
-    @param[in]  bad            A 2-d boolean NumPy array of values to emphasize in the plots
-    @param[in]  diff           difference array; a 2-d NumPy array, or None to show lhs-rhs
-    @param[in]  plotFileName   Filename to save the plot to.  If None, the plot will be displayed in a
-                               a window.
+    @param[in]  bad            A 2-d boolean NumPy array of values to emphasize
+                               in the plots
+    @param[in]  diff           difference array; a 2-d NumPy array, or None to
+                               show lhs-rhs
+    @param[in]  plotFileName   Filename to save the plot to.  If None, the plot
+                               will be displayed in a window.
     """
     from matplotlib import pyplot
     if diff is None:
@@ -487,22 +507,28 @@ def plotImageDiff(lhs, rhs, bad=None, diff=None, plotFileName=None):
     vmax1 = numpy.maximum(numpy.max(lhs), numpy.max(rhs))
     vmin2 = numpy.min(diff)
     vmax2 = numpy.max(diff)
-    for n, (image, title) in enumerate([(lhs, "lhs"), (rhs, "rhs"), (diff, "diff")]):
+    for n, (image, title) in enumerate([(lhs, "lhs"), (rhs, "rhs"),
+                                        (diff, "diff")]):
         pyplot.subplot(2, 3, n + 1)
-        im1 = pyplot.imshow(image, cmap=pyplot.cm.gray, interpolation='nearest', origin='lower',
-                            vmin=vmin1, vmax=vmax1)
+        im1 = pyplot.imshow(image, cmap=pyplot.cm.gray,
+                            interpolation='nearest',
+                            origin='lower', vmin=vmin1, vmax=vmax1)
         if bad is not None:
-            pyplot.imshow(badImage, alpha=0.2, interpolation='nearest', origin='lower')
+            pyplot.imshow(badImage, alpha=0.2,
+                          interpolation='nearest', origin='lower')
         pyplot.axis("off")
         pyplot.title(title)
         pyplot.subplot(2, 3, n + 4)
-        im2 = pyplot.imshow(image, cmap=pyplot.cm.gray, interpolation='nearest', origin='lower',
-                            vmin=vmin2, vmax=vmax2)
+        im2 = pyplot.imshow(image, cmap=pyplot.cm.gray,
+                            interpolation='nearest',
+                            origin='lower', vmin=vmin2, vmax=vmax2)
         if bad is not None:
-            pyplot.imshow(badImage, alpha=0.2, interpolation='nearest', origin='lower')
+            pyplot.imshow(badImage, alpha=0.2,
+                          interpolation='nearest', origin='lower')
         pyplot.axis("off")
         pyplot.title(title)
-    pyplot.subplots_adjust(left=0.05, bottom=0.05, top=0.92, right=0.75, wspace=0.05, hspace=0.05)
+    pyplot.subplots_adjust(left=0.05, bottom=0.05, top=0.92,
+                           right=0.75, wspace=0.05, hspace=0.05)
     cax1 = pyplot.axes([0.8, 0.55, 0.05, 0.4])
     pyplot.colorbar(im1, cax=cax1)
     cax2 = pyplot.axes([0.8, 0.05, 0.05, 0.4])
@@ -520,32 +546,42 @@ def assertFloatsAlmostEqual(testCase, lhs, rhs, rtol=sys.float_info.epsilon,
                             plotFileName=None, invert=False, msg=None):
     """!Highly-configurable floating point comparisons for scalars and arrays.
 
-    The test assertion will fail if all elements lhs and rhs are not equal to within the tolerances
-    specified by rtol and atol.  More precisely, the comparison is:
+    The test assertion will fail if all elements lhs and rhs are not equal to
+    within the tolerances specified by rtol and atol.  More precisely,
+    the comparison is:
 
     abs(lhs - rhs) <= relTo*rtol OR abs(lhs - rhs) <= atol
 
-    If rtol or atol is None, that term in the comparison is not performed at all.
+    If rtol or atol is None, that term in the comparison is not performed at
+    all.
 
-    When not specified, relTo is the elementwise maximum of the absolute values of lhs and rhs.  If
-    set manually, it should usually be set to either lhs or rhs, or a scalar value typical of what
-    is expected.
+    When not specified, relTo is the elementwise maximum of the absolute values
+    of lhs and rhs.  If set manually, it should usually be set to either lhs or
+    rhs, or a scalar value typical of what is expected.
 
     @param[in]  testCase       unittest.TestCase instance the test is part of
-    @param[in]  lhs            LHS value(s) to compare; may be a scalar or array-like of any dimension
-    @param[in]  rhs            RHS value(s) to compare; may be a scalar or array-like of any dimension
-    @param[in]  rtol           Relative tolerance for comparison; defaults to double-precision epsilon.
-    @param[in]  atol           Absolute tolerance for comparison; defaults to double-precision epsilon.
+    @param[in]  lhs            LHS value(s) to compare; may be a scalar or
+                               array-like of any dimension
+    @param[in]  rhs            RHS value(s) to compare; may be a scalar or
+                               array-like of any dimension
+    @param[in]  rtol           Relative tolerance for comparison; defaults to
+                               double-precision epsilon.
+    @param[in]  atol           Absolute tolerance for comparison; defaults to
+                               double-precision epsilon.
     @param[in]  relTo          Value to which comparison with rtol is relative.
-    @param[in]  printFailures  Upon failure, print all inequal elements as part of the message.
-    @param[in]  plotOnFailure  Upon failure, plot the originals and their residual with matplotlib.
+    @param[in]  printFailures  Upon failure, print all inequal elements as part
+                               of the message.
+    @param[in]  plotOnFailure  Upon failure, plot the originals and their
+                               residual with matplotlib.
                                Only 2-d arrays are supported.
-    @param[in]  plotFileName   Filename to save the plot to.  If None, the plot will be displayed in a
-                               a window.
-    @param[in]  invert         If True, invert the comparison and fail only if any elements *are* equal.
-                               Used to implement assertFloatsNotEqual, which should generally be used instead
-                               for clarity.
-    @param[in] msg             String to append to the error message when assert fails.
+    @param[in]  plotFileName   Filename to save the plot to.  If None, the plot
+                               will be displayed in a window.
+    @param[in]  invert         If True, invert the comparison and fail only if
+                               any elements *are* equal. Used to implement
+                               assertFloatsNotEqual, which should generally be
+                               used instead for clarity.
+    @param[in] msg             String to append to the error message when
+                               assert fails.
     """
     if not numpy.isfinite(lhs).all():
         testCase.fail("Non-finite values in lhs")
@@ -582,24 +618,29 @@ def assertFloatsAlmostEqual(testCase, lhs, rhs, rtol=sys.float_info.epsilon,
                           % (lhs, cmpStr, rhs, absDiff, atol)]
             elif atol is None:
                 errMsg = ["%s %s %s; diff=%s/%s=%s with rtol=%s"
-                          % (lhs, cmpStr, rhs, absDiff, relTo, absDiff/relTo, rtol)]
+                          % (lhs, cmpStr, rhs, absDiff, relTo, absDiff/relTo,
+                             rtol)]
             else:
                 errMsg = ["%s %s %s; diff=%s/%s=%s with rtol=%s, atol=%s"
-                          % (lhs, cmpStr, rhs, absDiff, relTo, absDiff/relTo, rtol, atol)]
+                          % (lhs, cmpStr, rhs, absDiff, relTo, absDiff/relTo,
+                             rtol, atol)]
         else:
             errMsg = ["%d/%d elements %s with rtol=%s, atol=%s"
                       % (bad.sum(), bad.size, failStr, rtol, atol)]
             if plotOnFailure:
                 if len(lhs.shape) != 2 or len(rhs.shape) != 2:
-                    raise ValueError("plotOnFailure is only valid for 2-d arrays")
+                    raise ValueError(
+                        "plotOnFailure is only valid for 2-d arrays")
                 try:
-                    plotImageDiff(lhs, rhs, bad, diff=diff, plotFileName=plotFileName)
+                    plotImageDiff(lhs, rhs, bad, diff=diff,
+                                  plotFileName=plotFileName)
                 except ImportError:
-                    errMsg.append("Failure plot requested but matplotlib could not be imported.")
+                    errMsg.append("Failure plot requested but matplotlib"
+                                  " could not be imported.")
             if printFailures:
-                # Make sure everything is an array if any of them are, so we can treat
-                # them the same (diff and absDiff are arrays if either rhs or lhs is),
-                # and we don't get here if neither is.
+                # Make sure everything is an array if any of them are, so we
+                # can treat them the same (diff and absDiff are arrays if
+                # either rhs or lhs is), and we don't get here if neither is.
                 if numpy.isscalar(relTo):
                     relTo = numpy.ones(bad.shape, dtype=float) * relTo
                 if numpy.isscalar(lhs):
@@ -608,10 +649,13 @@ def assertFloatsAlmostEqual(testCase, lhs, rhs, rtol=sys.float_info.epsilon,
                     rhs = numpy.ones(bad.shape, dtype=float) * rhs
                 if rtol is None:
                     for a, b, diff in zip(lhs[bad], rhs[bad], absDiff[bad]):
-                        errMsg.append("%s %s %s (diff=%s)" % (a, cmpStr, b, diff))
+                        errMsg.append("%s %s %s (diff=%s)" %
+                                      (a, cmpStr, b, diff))
                 else:
-                    for a, b, diff, rel in zip(lhs[bad], rhs[bad], absDiff[bad], relTo[bad]):
-                        errMsg.append("%s %s %s (diff=%s/%s=%s)" % (a, cmpStr, b, diff, rel, diff/rel))
+                    for a, b, diff, rel in zip(lhs[bad], rhs[bad],
+                                               absDiff[bad], relTo[bad]):
+                        errMsg.append("%s %s %s (diff=%s/%s=%s)" %
+                                      (a, cmpStr, b, diff, rel, diff/rel))
 
     if msg is not None:
         errMsg.append(msg)
@@ -621,7 +665,8 @@ def assertFloatsAlmostEqual(testCase, lhs, rhs, rtol=sys.float_info.epsilon,
 @inTestCase
 def assertFloatsNotEqual(testCase, lhs, rhs, **kwds):
     """
-    Fail a test if the given floating point values are equal to within the given tolerances.
+    Fail a test if the given floating point values are equal to within the
+    given tolerances.
 
     See assertClose for more information.
     """
@@ -635,18 +680,21 @@ def assertFloatsEqual(testCase, lhs, rhs, **kwargs):
 
     See assertClose (called with rtol=atol=0) for more information.
     """
-    return assertFloatsAlmostEqual(testCase, lhs, rhs, rtol=0, atol=0, **kwargs)
+    return assertFloatsAlmostEqual(testCase, lhs, rhs, rtol=0, atol=0,
+                                   **kwargs)
 
 
 @inTestCase
 def assertClose(*args, **kwargs):
-    warnings.warn("assertClose is deprecated; please use TestCase.assertFloatsAlmostEqual",
+    warnings.warn("assertClose is deprecated; please use"
+                  " TestCase.assertFloatsAlmostEqual",
                   DeprecationWarning)
     return assertFloatsAlmostEqual(*args, **kwargs)
 
 
 @inTestCase
 def assertNotClose(*args, **kwargs):
-    warnings.warn("assertNotClose is deprecated; please use TestCase.assertFloatsNotEqual",
+    warnings.warn("assertNotClose is deprecated; please use"
+                  " TestCase.assertFloatsNotEqual",
                   DeprecationWarning)
     return assertFloatsNotEqual(*args, **kwargs)

--- a/python/lsst/utils/wrappers.py
+++ b/python/lsst/utils/wrappers.py
@@ -55,7 +55,8 @@ def isAttributeSafeToTransfer(name, value):
 
 
 def continueClass(cls):
-    """Re-open the decorated class, adding any new definitions into the original.
+    """Re-open the decorated class, adding any new definitions into the
+    original.
 
     For example,
     ::
@@ -119,7 +120,8 @@ def inClass(cls, name=None):
                 name1 = func.__name__
             else:
                 if hasattr(func, "__func__"):
-                    # classmethod and staticmethod have __func__ but no __name__
+                    # classmethod and staticmethod have __func__ but no
+                    # __name__
                     name1 = func.__func__.__name__
                 elif hasattr(func, "fget"):
                     # property has fget but no __name__
@@ -262,8 +264,8 @@ class TemplateMeta(type):
     def __call__(self, *args, **kwds):
         # __call__ is invoked when someone tries to construct an instance of
         # the abstract base class.
-        # If the ABC defines a "TEMPLATE_PARAMS" attribute, we use those strings
-        # as the kwargs we should intercept to find the right type.
+        # If the ABC defines a "TEMPLATE_PARAMS" attribute, we use those
+        # strings as the kwargs we should intercept to find the right type.
         key = tuple(kwds.pop(p, d) for p, d in zip(self.TEMPLATE_PARAMS,
                                                    self.TEMPLATE_DEFAULTS))
         # indices are only tuples if there are multiple elements
@@ -364,7 +366,8 @@ class TemplateMeta(type):
             # indices are only tuples if there are multiple elements
             primaryKey = primaryKey[0]
         if self._registry.get(primaryKey, None) != subclass:
-            raise ValueError("Subclass is not registered with this base class.")
+            raise ValueError(
+                "Subclass is not registered with this base class.")
         self._registry[key] = subclass
 
     # Immutable mapping interface defined below.  We don't use collections

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [flake8]
-max-line-length = 110
+max-line-length = 79
 ignore = E133, E226, E228, N802, N803
-exclude = __init__.py
+exclude =
+  __init__.py,
+  .tests/

--- a/tests/testGetPackageDir.py
+++ b/tests/testGetPackageDir.py
@@ -30,7 +30,8 @@ from lsst.utils import getPackageDir
 class GetPackageDirTestCase(unittest.TestCase):
     def testBasics(self):
         utilsPath = getPackageDir("utils")
-        self.assertTrue(os.path.isfile(os.path.join(utilsPath, "tests", "testGetPackageDir.py")))
+        self.assertTrue(os.path.isfile(os.path.join(utilsPath, "tests",
+                                                    "testGetPackageDir.py")))
 
         # NOTE: one goal of this test is to confirm that the correct exception
         # is raised even if we haven't explicitly imported pex.exceptions.
@@ -41,7 +42,8 @@ class GetPackageDirTestCase(unittest.TestCase):
 
     def testUnicodeBasics(self):
         utilsPath = getPackageDir(u"utils")
-        self.assertTrue(os.path.isfile(os.path.join(utilsPath, "tests", "testGetPackageDir.py")))
+        self.assertTrue(os.path.isfile(os.path.join(utilsPath, "tests",
+                                                    "testGetPackageDir.py")))
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/testGetTempFilePath.py
+++ b/tests/testGetTempFilePath.py
@@ -46,7 +46,8 @@ class GetTempFilePathTestCase(unittest.TestCase):
     def runGetTempFile(self, funcName):
         with lsst.utils.tests.getTempFilePath(".fits") as tmpFile:
             baseName = os.path.basename(tmpFile)
-            self.assertEqual(baseName, "testGetTempFilePath_%s.fits" % (funcName,))
+            self.assertEqual(baseName,
+                             "testGetTempFilePath_%s.fits" % (funcName,))
             f = open(tmpFile, "w")
             f.write("foo\n")
             f.close()

--- a/tests/testLockProtection.py
+++ b/tests/testLockProtection.py
@@ -49,7 +49,8 @@ class LockProtectedTestCase(lsst.utils.tests.TestCase):
             with mc:
                 mc.danger()
         except multithreading.UnsafeAccessError:
-            self.fail("Raised multithreading.UnsafeAccessError inside of context manager!")
+            self.fail("Raised multithreading.UnsafeAccessError"
+                      " inside of context manager!")
 
     def testSharedLock(self):
         mc = MyClass(multithreading.SharedLock())
@@ -58,7 +59,8 @@ class LockProtectedTestCase(lsst.utils.tests.TestCase):
             with mc:
                 mc.danger()
         except multithreading.UnsafeAccessError:
-            self.fail("Raised multithreading.UnsafeAccessError inside of context manager!")
+            self.fail("Raised multithreading.UnsafeAccessError"
+                      " inside of context manager!")
 
     def testSharedData(self):
         mc = MyClass(multithreading.SharedData())
@@ -67,7 +69,8 @@ class LockProtectedTestCase(lsst.utils.tests.TestCase):
             with mc:
                 mc.danger()
         except multithreading.UnsafeAccessError:
-            self.fail("Raised multithreading.UnsafeAccessError inside of context manager!")
+            self.fail("Raised multithreading.UnsafeAccessError"
+                      " inside of context manager!")
 
     def testExitViaException(self):
         mc = MyClass(multithreading.SharedLock())

--- a/tests/testOrdering.py
+++ b/tests/testOrdering.py
@@ -32,11 +32,13 @@ class TestCaseOrdering(lsst.utils.tests.TestCase):
         class DummyMemoryTest(lsst.utils.tests.MemoryTestCase):
             pass
 
-        suite = unittest.defaultTestLoader.suiteClass([DummyMemoryTest("testLeaks"),
-                                                       DummyTest("noOp")])
+        suite = unittest.defaultTestLoader.suiteClass(
+            [DummyMemoryTest("testLeaks"), DummyTest("noOp")])
 
-        self.assertNotIsInstance(suite._tests[0], lsst.utils.tests.MemoryTestCase)
-        self.assertIsInstance(suite._tests[-1], lsst.utils.tests.MemoryTestCase)
+        self.assertNotIsInstance(suite._tests[0],
+                                 lsst.utils.tests.MemoryTestCase)
+        self.assertIsInstance(suite._tests[-1],
+                              lsst.utils.tests.MemoryTestCase)
 
 
 if __name__ == "__main__":

--- a/tests/testPybind11.py
+++ b/tests/testPybind11.py
@@ -76,35 +76,46 @@ class Pybind11TestCase(lsst.utils.tests.TestCase):
 
     def assertAccepts(self, function, value, msg):
         try:
-            self.assertEqual(function(value), value, msg="%s: %r != %r" % (msg, function(value), value))
+            self.assertEqual(function(value), value,
+                             msg="%s: %r != %r" % (msg, function(value),
+                                                   value))
         except TypeError:
             self.fail(msg)
 
     def checkNumeric(self, function):
-        self.assertAccepts(function, int(1), msg="Failure passing int to %s" % function.__name__)
-        self.assertAccepts(function, long(1), msg="Failure passing long to %s" % function.__name__)
+        self.assertAccepts(function, int(1),
+                           msg="Failure passing int to %s" % function.__name__)
+        self.assertAccepts(function, long(1),
+                           msg="Failure passing long to %s" %
+                               function.__name__)
+        # should fail to convert even numeric strings
         self.assertRaises((TypeError, NotImplementedError),
-                          function, "5")  # should fail to convert even numeric strings
-        # We should be able to coerce integers with different signedness and size to any numeric
-        # type argument (as long as we don't trigger overflow)
+                          function, "5")
+        # We should be able to coerce integers with different signedness and
+        # size to any numeric type argument (as long as we don't trigger
+        # overflow)
         for size in (8, 16, 32, 64):
             for name in ("int%d" % size, "uint%d" % size):
                 array = numpy.ones(1, dtype=getattr(numpy, name))
                 self.assertAccepts(function, array[0],
-                                   msg="Failure passing numpy.%s to %s" % (name, function.__name__))
+                                   msg="Failure passing numpy.%s to %s" %
+                                       (name, function.__name__))
 
     def checkFloating(self, function):
         self.checkNumeric(function)
-        self.assertAccepts(function, float(3.5), "Failure passing float to %s" % function.__name__)
+        self.assertAccepts(function, float(3.5),
+                           "Failure passing float to %s" % function.__name__)
 
     def checkInteger(self, function, size):
-        """If we pass an integer that doesn't fit in the C++ argument type, we should raise OverflowError"""
+        """If we pass an integer that doesn't fit in the C++ argument type,
+        we should raise OverflowError"""
         self.checkNumeric(function)
         tooBig = 2**(size + 1)
         self.assertRaises(OverflowError, function, tooBig)
 
     def testFloatingPoints(self):
-        """Test our customized numeric scalar typemaps, including support for NumPy scalars."""
+        """Test our customized numeric scalar typemaps, including support
+        for NumPy scalars."""
         self.checkFloating(_example.accept_float32)
         self.checkFloating(_example.accept_cref_float32)
         self.checkFloating(_example.accept_cref_float64)
@@ -114,12 +125,15 @@ class Pybind11TestCase(lsst.utils.tests.TestCase):
         for size in (8, 16, 32, 64):
             self.checkInteger(getattr(_example, "accept_int%d" % size), size)
             self.checkInteger(getattr(_example, "accept_uint%d" % size), size)
-            self.checkInteger(getattr(_example, "accept_cref_int%d" % size), size)
-            self.checkInteger(getattr(_example, "accept_cref_uint%d" % size), size)
+            self.checkInteger(
+                getattr(_example, "accept_cref_int%d" % size), size)
+            self.checkInteger(
+                getattr(_example, "accept_cref_uint%d" % size), size)
         # Test that we choose the floating point overload when we pass a float,
         # and we get the integer overload when we pass an int.
-        # We can't ever distinguish between different kinds of ints or different
-        # kinds of floats in an overloading context, but that's a Pybind11 limitation.
+        # We can't ever distinguish between different kinds of ints or
+        # different kinds of floats in an overloading context, but that's a
+        # Pybind11 limitation.
 
     def testOverloads(self):
         self.assertEqual(_example.getName(int(1)), "int")
@@ -129,7 +143,8 @@ class Pybind11TestCase(lsst.utils.tests.TestCase):
         """Test the 1-axis (2 argument) version of cppIndex
         """
         # loop over various sizes
-        # note that when size == 0 no indices are valid, but the "invalid indices" tests still run
+        # note that when size == 0 no indices are valid, but the "invalid
+        # indices" tests still run
         for size in range(4):
             # loop over all valid indices
             for ind in range(size):
@@ -161,15 +176,21 @@ class Pybind11TestCase(lsst.utils.tests.TestCase):
                 # loop over all valid indices
                 for ind0 in range(size0):
                     for ind1 in range(size1):
-                        # negative indices that point to the same element as the positive index
+                        # negative indices that point to the same element as
+                        # the positive index
                         negind0 = ind0 - size0
                         negind1 = ind1 - size1
 
                         # both indeces valid
-                        self.assertEqual(cppIndex(size0, size1, ind0, ind1), (ind0, ind1))
-                        self.assertEqual(cppIndex(size0, size1, ind0, negind1), (ind0, ind1))
-                        self.assertEqual(cppIndex(size0, size1, negind0, ind1), (ind0, ind1))
-                        self.assertEqual(cppIndex(size0, size1, negind0, negind1), (ind0, ind1))
+                        self.assertEqual(cppIndex(size0, size1, ind0, ind1),
+                                         (ind0, ind1))
+                        self.assertEqual(cppIndex(size0, size1, ind0, negind1),
+                                         (ind0, ind1))
+                        self.assertEqual(cppIndex(size0, size1, negind0, ind1),
+                                         (ind0, ind1))
+                        self.assertEqual(cppIndex(size0, size1,
+                                                  negind0, negind1),
+                                         (ind0, ind1))
 
                         # one index invalid
                         with self.assertRaises(IndexError):
@@ -181,7 +202,8 @@ class Pybind11TestCase(lsst.utils.tests.TestCase):
                         with self.assertRaises(IndexError):
                             cppIndex(size0, size1, negbad0, ind1)
 
-                        # both indices invalid (just test the invalid indices closest to 0)
+                        # both indices invalid (just test the invalid indices
+                        # closest to 0)
                         with self.assertRaises(IndexError):
                             cppIndex(size0, size1, size0, size1)
                         with self.assertRaises(IndexError):

--- a/tests/testRaDecToStr.py
+++ b/tests/testRaDecToStr.py
@@ -98,17 +98,21 @@ class RaDecToStrTestCase(lsst.utils.tests.TestCase):
             decRad = decDeg*math.pi/180.
             for delim in ['_', ' ']:
                 self.assertAlmostEqual(
-                    lsstutils.raStrToRad(raStr.replace(':', delim), delim), raRad, 6)
+                    lsstutils.raStrToRad(raStr.replace(':', delim), delim),
+                    raRad, 6)
                 self.assertAlmostEqual(
-                    lsstutils.decStrToRad(decStr.replace(':', delim), delim), decRad, 6)
+                    lsstutils.decStrToRad(decStr.replace(':', delim), delim),
+                    decRad, 6)
 
     def testStrToDegDelim(self):
         for raDeg, decDeg, raStr, decStr in self.goodData:
             for delim in ['_', ' ']:
                 self.assertAlmostEqual(
-                    lsstutils.raStrToDeg(raStr.replace(':', delim), delim), raDeg, 4)
+                    lsstutils.raStrToDeg(raStr.replace(':', delim), delim),
+                    raDeg, 4)
                 self.assertAlmostEqual(
-                    lsstutils.decStrToDeg(decStr.replace(':', delim), delim), decDeg, 3)
+                    lsstutils.decStrToDeg(decStr.replace(':', delim), delim),
+                    decDeg, 3)
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/testSharedData.py
+++ b/tests/testSharedData.py
@@ -42,7 +42,8 @@ class ShareDataTestCase(unittest.TestCase):
         self.sd.acquire()
         self.assertTrue(self.sd._is_owned(), "lock not kept")
         self.sd.release()
-        self.assertTrue(self.sd._is_owned(), "lock not kept after partial release")
+        self.assertTrue(self.sd._is_owned(),
+                        "lock not kept after partial release")
         self.sd.release()
         self.assertFalse(self.sd._is_owned(), "lock not released")
 
@@ -107,7 +108,8 @@ class ShareDataTestCase(unittest.TestCase):
         with self.sd:
             self.sd.lname = "Plante"
             attrs = self.sd.dir()
-            self.assertEqual(len(attrs), 4, "Wrong number of items: " + str(attrs))
+            self.assertEqual(len(attrs), 4,
+                             "Wrong number of items: " + str(attrs))
             self.assertEqual(self.sd.lname, "Plante")
 
 
@@ -123,7 +125,8 @@ class ReadableShareDataTestCase(unittest.TestCase):
         self.sd.acquire()
         self.assertTrue(self.sd._is_owned(), "lock not kept")
         self.sd.release()
-        self.assertTrue(self.sd._is_owned(), "lock not kept after partial release")
+        self.assertTrue(self.sd._is_owned(),
+                        "lock not kept after partial release")
         self.sd.release()
         self.assertFalse(self.sd._is_owned(), "lock not released")
 
@@ -178,7 +181,8 @@ class ReadableShareDataTestCase(unittest.TestCase):
         with self.sd:
             self.sd.lname = "Plante"
             attrs = self.sd.dir()
-            self.assertEqual(len(attrs), 4, "Wrong number of items: " + str(attrs))
+            self.assertEqual(len(attrs), 4,
+                             "Wrong number of items: " + str(attrs))
             self.assertEqual(self.sd.lname, "Plante")
 
 

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -40,7 +40,8 @@ class UtilsTestCase(lsst.utils.tests.TestCase):
         self.larges2 = np.zeros((5, 5), dtype=float) + self.large
         self.largesOneOff = self.larges.copy()
         self.largesOneOff[0] += self.epsilon
-        self.largesEpsilon = np.zeros((5, 5), dtype=float) + self.large + self.epsilon
+        self.largesEpsilon = np.zeros((5, 5), dtype=float) + \
+            self.large + self.epsilon
         self.ranges = np.arange(-12., 13.).reshape(5, 5)
         self.rangesEpsilon = self.ranges.copy()
         self.rangesEpsilon += np.linspace(-1E-4, 1E-4, 5.)
@@ -50,45 +51,61 @@ class UtilsTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(0.0, 0.0)
         self.assertFloatsAlmostEqual(0.0, 1E-8, atol=1E-7)
         self.assertFloatsAlmostEqual(0.0, 1E-8, atol=1E-7, rtol=None)
-        self.assertFloatsAlmostEqual(0.0, 1E-8, atol=None, rtol=1E-5, relTo=1E-2)
+        self.assertFloatsAlmostEqual(0.0, 1E-8, atol=None,
+                                     rtol=1E-5, relTo=1E-2)
 
         # zero array vs. scalar tests
         self.assertFloatsAlmostEqual(self.zeros, 0.)
         self.assertFloatsAlmostEqual(self.zeros, self.epsilon, atol=1E-7)
-        self.assertFloatsAlmostEqual(self.zeros, self.epsilon, atol=1E-7, rtol=None)
-        self.assertFloatsAlmostEqual(self.zeros, self.epsilon, atol=None, rtol=1E-5, relTo=1E-2)
+        self.assertFloatsAlmostEqual(self.zeros, self.epsilon,
+                                     atol=1E-7, rtol=None)
+        self.assertFloatsAlmostEqual(self.zeros, self.epsilon,
+                                     atol=None, rtol=1E-5, relTo=1E-2)
 
         # zero array vs. array tests
         self.assertFloatsAlmostEqual(self.zeros, self.zeros2)
         self.assertFloatsAlmostEqual(self.zeros, self.zeros2, rtol=None)
         self.assertFloatsAlmostEqual(self.zeros, self.zeros2, atol=None)
         self.assertFloatsAlmostEqual(self.zeros, self.epsilons, atol=1E-7)
-        self.assertFloatsAlmostEqual(self.zeros, self.epsilons, atol=1E-7, rtol=None)
-        self.assertFloatsAlmostEqual(self.zeros, self.epsilons, atol=None, rtol=1E-5, relTo=1E-2)
+        self.assertFloatsAlmostEqual(self.zeros, self.epsilons,
+                                     atol=1E-7, rtol=None)
+        self.assertFloatsAlmostEqual(self.zeros, self.epsilons,
+                                     atol=None, rtol=1E-5, relTo=1E-2)
 
         # invalid value tests
         with self.assertRaises(ValueError):
-            self.assertFloatsAlmostEqual(self.zeros, self.zeros2, atol=None, rtol=None)
+            self.assertFloatsAlmostEqual(
+                self.zeros, self.zeros2, atol=None, rtol=None)
 
         # non-zero scalar tests
         self.assertFloatsAlmostEqual(self.large, 100.)
-        self.assertFloatsAlmostEqual(self.large, self.large + self.epsilon, rtol=1E-7)
-        self.assertFloatsAlmostEqual(self.large, self.large + self.epsilon, rtol=1E-7, atol=None)
-        self.assertFloatsAlmostEqual(self.large, self.large + self.epsilon, rtol=1E-7, relTo=100.0)
+        self.assertFloatsAlmostEqual(self.large, self.large + self.epsilon,
+                                     rtol=1E-7)
+        self.assertFloatsAlmostEqual(self.large, self.large + self.epsilon,
+                                     rtol=1E-7, atol=None)
+        self.assertFloatsAlmostEqual(self.large, self.large + self.epsilon,
+                                     rtol=1E-7, relTo=100.0)
 
         # Non-zero array vs. scalar tests
         self.assertFloatsAlmostEqual(self.larges, self.large)
-        self.assertFloatsAlmostEqual(self.larges, self.large + self.epsilon, rtol=1E-7)
-        self.assertFloatsAlmostEqual(self.larges, self.large + self.epsilon, rtol=1E-7, atol=None)
-        self.assertFloatsAlmostEqual(self.larges, self.large + self.epsilon, rtol=1E-7, relTo=100.0)
+        self.assertFloatsAlmostEqual(self.larges, self.large + self.epsilon,
+                                     rtol=1E-7)
+        self.assertFloatsAlmostEqual(self.larges, self.large + self.epsilon,
+                                     rtol=1E-7, atol=None)
+        self.assertFloatsAlmostEqual(self.larges, self.large + self.epsilon,
+                                     rtol=1E-7, relTo=100.0)
 
         # Non-zero array vs. array tests
         self.assertFloatsAlmostEqual(self.larges, self.larges2)
-        self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon, rtol=1E-7)
-        self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon, rtol=1E-7, atol=None)
-        self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon, rtol=1E-7, relTo=100.0)
+        self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon,
+                                     rtol=1E-7)
+        self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon,
+                                     rtol=1E-7, atol=None)
+        self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon,
+                                     rtol=1E-7, relTo=100.0)
         self.assertFloatsAlmostEqual(self.larges, self.largesOneOff, atol=1e-7)
-        self.assertFloatsAlmostEqual(self.ranges, self.rangesEpsilon, rtol=1E-3, atol=1E-4)
+        self.assertFloatsAlmostEqual(self.ranges, self.rangesEpsilon,
+                                     rtol=1E-3, atol=1E-4)
 
         # Test that it raises appropriately
         with self.assertRaises(AssertionError):
@@ -125,27 +142,36 @@ class UtilsTestCase(lsst.utils.tests.TestCase):
             self.assertFloatsAlmostEqual(0., self.larges, atol=1e-2, rtol=None)
 
         with self.assertRaises(AssertionError):
-            self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon, rtol=1E-16)
+            self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon,
+                                         rtol=1E-16)
         with self.assertRaises(AssertionError):
-            self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon, rtol=1E-16, atol=None)
+            self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon,
+                                         rtol=1E-16, atol=None)
         with self.assertRaises(AssertionError):
-            self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon, rtol=1E-16, relTo=100.0)
+            self.assertFloatsAlmostEqual(self.larges, self.largesEpsilon,
+                                         rtol=1E-16, relTo=100.0)
         with self.assertRaises(AssertionError):
-            self.assertFloatsAlmostEqual(self.larges, self.largesOneOff, atol=1e-16)
+            self.assertFloatsAlmostEqual(self.larges, self.largesOneOff,
+                                         atol=1e-16)
         with self.assertRaises(AssertionError):
-            self.assertFloatsAlmostEqual(self.larges, self.largesOneOff, atol=1e-16, rtol=None)
+            self.assertFloatsAlmostEqual(self.larges, self.largesOneOff,
+                                         atol=1e-16, rtol=None)
         with self.assertRaises(AssertionError):
-            self.assertFloatsAlmostEqual(self.ranges, self.rangesEpsilon, rtol=1E-15, atol=1E-4)
+            self.assertFloatsAlmostEqual(self.ranges, self.rangesEpsilon,
+                                         rtol=1E-15, atol=1E-4)
 
         if display:
-            # should see failures on the center row of the 5x5 image, but not the very center point
+            # should see failures on the center row of the 5x5 image, but not
+            # the very center point
             nonzeroCenter = self.zeros.copy()
             nonzeroCenter[2, :] = 1e-5
             with self.assertRaises(AssertionError):
-                self.assertFloatsAlmostEqual(self.zeros, nonzeroCenter, rtol=1E-6, plotOnFailure=True)
+                self.assertFloatsAlmostEqual(self.zeros, nonzeroCenter,
+                                             rtol=1E-6, plotOnFailure=True)
 
         with self.assertRaises(AssertionError) as cm:
-            self.assertFloatsAlmostEqual(10, 0, msg="This is an error message.")
+            self.assertFloatsAlmostEqual(10, 0,
+                                         msg="This is an error message.")
         self.assertIn("This is an error message.", str(cm.exception))
         self.assertIn("10 != 0; diff=10/10=1.0 with rtol=", str(cm.exception))
 
@@ -159,40 +185,57 @@ class UtilsTestCase(lsst.utils.tests.TestCase):
         # zero array vs. scalar tests
         self.assertFloatsNotEqual(self.zeros, 1.)
         self.assertFloatsNotEqual(self.zeros, self.epsilon, atol=1E-9)
-        self.assertFloatsNotEqual(self.zeros, self.epsilon, atol=1E-9, rtol=None)
-        self.assertFloatsNotEqual(self.zeros, self.epsilon, atol=None, rtol=1E-7, relTo=1E-2)
+        self.assertFloatsNotEqual(self.zeros, self.epsilon,
+                                  atol=1E-9, rtol=None)
+        self.assertFloatsNotEqual(self.zeros, self.epsilon, atol=None,
+                                  rtol=1E-7, relTo=1E-2)
 
         # zero array vs. array tests
         self.assertFloatsNotEqual(self.zeros, self.larges)
-        self.assertFloatsNotEqual(self.zeros, self.epsilon, atol=1E-9, rtol=None)
-        self.assertFloatsNotEqual(self.zeros, self.epsilon, atol=None, rtol=1e-5, relTo=1e-5)
+        self.assertFloatsNotEqual(self.zeros, self.epsilon,
+                                  atol=1E-9, rtol=None)
+        self.assertFloatsNotEqual(self.zeros, self.epsilon, atol=None,
+                                  rtol=1e-5, relTo=1e-5)
         self.assertFloatsNotEqual(self.zeros, self.epsilons, atol=1E-9)
-        self.assertFloatsNotEqual(self.zeros, self.epsilons, atol=1E-9, rtol=None)
-        self.assertFloatsNotEqual(self.zeros, self.epsilons, atol=None, rtol=1E-7, relTo=1E-2)
+        self.assertFloatsNotEqual(self.zeros, self.epsilons,
+                                  atol=1E-9, rtol=None)
+        self.assertFloatsNotEqual(self.zeros, self.epsilons, atol=None,
+                                  rtol=1E-7, relTo=1E-2)
 
         # invalid value tests
         with self.assertRaises(ValueError):
-            self.assertFloatsNotEqual(self.zeros, self.zeros2, atol=None, rtol=None)
+            self.assertFloatsNotEqual(self.zeros, self.zeros2,
+                                      atol=None, rtol=None)
 
         # non-zero scalar tests
         self.assertFloatsNotEqual(self.large, 1.)
-        self.assertFloatsNotEqual(self.large, self.large + self.epsilon, atol=1E-9)
-        self.assertFloatsNotEqual(self.large, self.large + self.epsilon, rtol=1E-11, atol=None)
-        self.assertFloatsNotEqual(self.large, self.large + self.epsilon, rtol=1E-12, relTo=1.)
+        self.assertFloatsNotEqual(self.large, self.large + self.epsilon,
+                                  atol=1E-9)
+        self.assertFloatsNotEqual(self.large, self.large + self.epsilon,
+                                  rtol=1E-11, atol=None)
+        self.assertFloatsNotEqual(self.large, self.large + self.epsilon,
+                                  rtol=1E-12, relTo=1.)
 
         # Non-zero array vs. scalar tests
-        self.assertFloatsNotEqual(self.larges, self.large + self.epsilon, atol=1e-9)
-        self.assertFloatsNotEqual(self.larges, self.large + self.epsilon, atol=1e-9, rtol=None)
-        self.assertFloatsNotEqual(self.larges, self.large + self.epsilon, rtol=1E-11, atol=None)
-        self.assertFloatsNotEqual(self.larges, self.large + self.epsilon, rtol=1E-12, relTo=1.)
+        self.assertFloatsNotEqual(self.larges, self.large + self.epsilon,
+                                  atol=1e-9)
+        self.assertFloatsNotEqual(self.larges, self.large + self.epsilon,
+                                  atol=1e-9, rtol=None)
+        self.assertFloatsNotEqual(self.larges, self.large + self.epsilon,
+                                  rtol=1E-11, atol=None)
+        self.assertFloatsNotEqual(self.larges, self.large + self.epsilon,
+                                  rtol=1E-12, relTo=1.)
 
         # Non-zero array vs. array tests
         self.assertFloatsNotEqual(self.larges, self.zeros)
         self.assertFloatsNotEqual(self.larges, self.largesEpsilon, rtol=1E-12)
-        self.assertFloatsNotEqual(self.larges, self.largesEpsilon, rtol=1E-12, atol=None)
-        self.assertFloatsNotEqual(self.larges, self.largesEpsilon, rtol=1E-11, relTo=100.0)
+        self.assertFloatsNotEqual(self.larges, self.largesEpsilon,
+                                  rtol=1E-12, atol=None)
+        self.assertFloatsNotEqual(self.larges, self.largesEpsilon,
+                                  rtol=1E-11, relTo=100.0)
         self.assertFloatsNotEqual(self.larges, self.largesOneOff, atol=1e-9)
-        self.assertFloatsNotEqual(self.larges, self.largesOneOff, atol=1e-9, rtol=None)
+        self.assertFloatsNotEqual(self.larges, self.largesOneOff,
+                                  atol=1e-9, rtol=None)
         self.assertFloatsNotEqual(self.ranges, self.rangesEpsilon)
 
         with self.assertRaises(AssertionError) as cm:

--- a/tests/testWrappers.py
+++ b/tests/testWrappers.py
@@ -159,7 +159,8 @@ class TemplateMetaSimpleTestCase(lsst.utils.tests.TestCase):
         d = self.ExampleD()
         self.assertIsInstance(f, self.Example)
         self.assertIsInstance(d, self.Example)
-        self.assertEqual(set(self.Example.__subclasses__()), set([self.ExampleF, self.ExampleD]))
+        self.assertEqual(set(self.Example.__subclasses__()),
+                         set([self.ExampleF, self.ExampleD]))
 
     def testConstruction(self):
         self.register()
@@ -201,7 +202,8 @@ class TemplateMetaSimpleTestCase(lsst.utils.tests.TestCase):
                          set([(np.float32, self.ExampleF),
                               (np.float64, self.ExampleD)]))
         self.assertEqual(len(self.Example), 2)
-        self.assertEqual(set(iter(self.Example)), set([np.float32, np.float64]))
+        self.assertEqual(set(iter(self.Example)),
+                         set([np.float32, np.float64]))
         self.assertEqual(self.Example.get(np.float64), self.ExampleD)
         self.assertEqual(self.Example.get(np.int32, False), False)
 

--- a/tests/test_get_caller_name.py
+++ b/tests/test_get_caller_name.py
@@ -31,7 +31,8 @@ class GetCallerNameTestCase(unittest.TestCase):
     """Test get_caller_name
 
     Warning: due to the different ways this can be run
-    (e.g. directly or py.test, the module name can be one of two different things)
+    (e.g. directly or py.test, the module name can be one of two
+    different things)
     """
 
     def test_free_function(self):
@@ -65,9 +66,12 @@ class GetCallerNameTestCase(unittest.TestCase):
             return get_caller_name(skip)
 
         result = test_func(2)
-        self.assertEquals(result, "{}.GetCallerNameTestCase.test_skip".format(__name__))
+        self.assertEquals(result,
+                          "{}.GetCallerNameTestCase.test_skip".format(__name__)
+                          )
 
-        result = test_func(2000000)  # use a large number to avoid details of how the test is run
+        # use a large number to avoid details of how the test is run
+        result = test_func(2000000)
         self.assertEquals(result, "")
 
 


### PR DESCRIPTION
This commit implements RFC-107 for the utils package. The good news is that autopep8 does work. The bad news is that:

1. it sometimes makes some very bad aesthetic choices. Especially if multiple parentheses are involved in the block.
2. it doesn't completely fix everything so there will be lines left broken. In particular doc strings (or any quoted strings) will not be fixed up.

Therefore these commits are about 30% automated and the rest manual.