### PR TITLE
DM-13046: Add random component to getTempFilePath filename

### DIFF
--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -36,6 +36,7 @@ import unittest
 import warnings
 import numpy
 import functools
+import tempfile
 
 # File descriptor leak test will be skipped if psutil can not be imported
 try:
@@ -360,6 +361,8 @@ def getTempFilePath(ext):
     If the with block completes successfully then the file is deleted, if possible;
     failure results in a printed warning.
     If the block exits with an exception the file if left on disk so it can be examined.
+    The file name has a random component such that nested context managers can be used
+    with the same file suffix.
 
     @param[in] ext  file name extension, e.g. ".fits"
     @return path for a temporary file. The path is a combination of the caller's file path
@@ -400,8 +403,8 @@ def getTempFilePath(ext):
     outDir = os.path.join(callerDir, ".tests")
     if not os.path.isdir(outDir):
         outDir = ""
-    outName = "%s_%s%s" % (callerFileName, callerFuncName, ext)
-    outPath = os.path.join(outDir, outName)
+    prefix = "%s_%s-" % (callerFileName, callerFuncName)
+    outPath = tempfile.mktemp(dir=outDir, suffix=ext, prefix=prefix)
     yield outPath
     if os.path.isfile(outPath):
         try:

--- a/tests/test_getTempFilePath.py
+++ b/tests/test_getTempFilePath.py
@@ -27,6 +27,18 @@ import time
 import lsst.utils.tests
 
 
+"""
+This file contains tests for lsst.utils.tests.getTempFilePath.
+
+The TestNameClashN classes are used to check that getTempFilePath
+does not use the same name across different test classes in the same
+file even if they have the same test methods. They are distinct classes
+with the same test method in an attempt to trigger a race condition
+whereby context managers use the same name and race to delete the file.
+The sleeps are there to ensure the race condition occurs in older versions
+of this package. This should not happen as of DM-13046."""
+
+
 class GetTempFilePathTestCase(unittest.TestCase):
     def testBasics(self):
         with lsst.utils.tests.getTempFilePath(".txt") as tmpFile:
@@ -81,9 +93,6 @@ class TestNested(unittest.TestCase):
 
 
 class TestNameClash1(unittest.TestCase):
-    """The TestNameClashN classes are used to check that getTempFilePath
-    does not use the same name across different test classes in the same
-    file even if they have the same test methods."""
 
     def testClash(self):
         """Create the temp file and pause before trying to delete it."""

--- a/tests/test_getTempFilePath.py
+++ b/tests/test_getTempFilePath.py
@@ -22,6 +22,7 @@
 import sys
 import unittest
 import os.path
+import time
 
 import lsst.utils.tests
 
@@ -59,6 +60,42 @@ class GetTempFilePathTestCase(unittest.TestCase):
     def runLevel3(self, funcName):
         """Call runLevel2, which calls runGetTempFile"""
         self.runLevel2(funcName)
+
+
+class TestNameClash1(unittest.TestCase):
+    """The TestNameClashN classes are used to check that getTempFilePath
+    does not use the same name across different test classes in the same
+    file even if they have the same test methods."""
+
+    def testClash(self):
+        """Create the temp file and pause before trying to delete it."""
+        with lsst.utils.tests.getTempFilePath(".fits") as tmpFile:
+            with open(tmpFile, "w") as f:
+                f.write("foo\n")
+            time.sleep(0.2)
+            self.assertTrue(os.path.exists(tmpFile))
+
+
+class TestNameClash2(unittest.TestCase):
+
+    def testClash(self):
+        """Pause a little before trying to create the temp file. The pause
+        time is less than the time that TestNameClash1 is pausing."""
+        with lsst.utils.tests.getTempFilePath(".fits") as tmpFile:
+            time.sleep(0.1)
+            with open(tmpFile, "w") as f:
+                f.write("foo\n")
+            self.assertTrue(os.path.exists(tmpFile))
+
+
+class TestNameClash3(unittest.TestCase):
+
+    def testClash(self):
+        """Create temp file and remove it without pauses."""
+        with lsst.utils.tests.getTempFilePath(".fits") as tmpFile:
+            with open(tmpFile, "w") as f:
+                f.write("foo\n")
+            self.assertTrue(os.path.exists(tmpFile))
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_getTempFilePath.py
+++ b/tests/test_getTempFilePath.py
@@ -64,6 +64,22 @@ class GetTempFilePathTestCase(unittest.TestCase):
         self.runLevel2(funcName)
 
 
+class TestNested(unittest.TestCase):
+    """Tests of the use of getTempFilePath in nested context managers."""
+
+    def testNested(self):
+        with lsst.utils.tests.getTempFilePath(".fits") as tmpFile1:
+            with lsst.utils.tests.getTempFilePath(".fits") as tmpFile2:
+                self.assertNotEqual(tmpFile1, tmpFile2)
+                with open(tmpFile1, "w") as f1:
+                    f1.write("foo\n")
+                with open(tmpFile2, "w") as f2:
+                    f2.write("foo\n")
+            self.assertTrue(os.path.exists(tmpFile1))
+            self.assertFalse(os.path.exists(tmpFile2))
+        self.assertFalse(os.path.exists(tmpFile1))
+
+
 class TestNameClash1(unittest.TestCase):
     """The TestNameClashN classes are used to check that getTempFilePath
     does not use the same name across different test classes in the same

--- a/tests/test_getTempFilePath.py
+++ b/tests/test_getTempFilePath.py
@@ -30,8 +30,9 @@ import lsst.utils.tests
 class GetTempFilePathTestCase(unittest.TestCase):
     def testBasics(self):
         with lsst.utils.tests.getTempFilePath(".txt") as tmpFile:
-            baseName = os.path.basename(tmpFile)
-            self.assertEqual(baseName, "test_getTempFilePath_testBasics.txt")
+            # Path will have unique component so do not test full equality
+            self.assertIn("test_getTempFilePath_testBasics", tmpFile)
+            self.assertTrue(tmpFile.endswith(".txt"))
             f = open(tmpFile, "w")
             f.write("foo\n")
             f.close()
@@ -46,8 +47,9 @@ class GetTempFilePathTestCase(unittest.TestCase):
 
     def runGetTempFile(self, funcName):
         with lsst.utils.tests.getTempFilePath(".fits") as tmpFile:
-            baseName = os.path.basename(tmpFile)
-            self.assertEqual(baseName, "test_getTempFilePath_%s.fits" % (funcName,))
+            # Path will have unique component so do not test full equality
+            self.assertIn("test_getTempFilePath_%s" % (funcName,), tmpFile)
+            self.assertTrue(tmpFile.endswith(".fits"))
             f = open(tmpFile, "w")
             f.write("foo\n")
             f.close()


### PR DESCRIPTION
This fixes getTempFilePath such that there is a little bit of randomness in the constructed name. This has two major benefits:

* meas_base can have two test classes in the same file sharing the same test method names.
* you can now have nested context managers with the same file suffix. This I think will make @danielsf very happy since it was clear that lots of sims tests would have benefited from this.