### PR TITLE
DM-10066: Provide utility function for wrapping operator<<

### DIFF
--- a/include/lsst/utils/python.h
+++ b/include/lsst/utils/python.h
@@ -88,6 +88,23 @@ void addOutputOp(PyClass &cls, std::string const &method) {
 }
 
 /**
+ * Add `__hash__` method implemented by `std::hash`.
+ *
+ * @tparam PyClass The pybind11 class_ type. The wrapped class must
+ *                 have an enabled specialization of `std::hash`.
+ *
+ * @param cls The `PyClass` object to which to add a wrapper.
+ */
+template <class PyClass>
+void addHash(PyClass &cls) {
+    using Class = typename PyClass::type;
+    cls.def("__hash__", [](Class const &self) {
+        static auto const hash = std::hash<Class>();
+        return hash(self);
+    });
+}
+
+/**
 Compute a C++ index from a Python index (negative values count from the end) and range-check.
 
 @param[in] size  Number of elements in the collection.

--- a/include/lsst/utils/python.h
+++ b/include/lsst/utils/python.h
@@ -65,6 +65,29 @@ inline void addSharedPtrEquality(PyClass & cls) {
 }
 
 /**
+ * Add `__str__` or `__repr__` method implemented by `operator<<`.
+ *
+ * For flexibility, this method can be used to define one or both of
+ * `__str__` and `__repr__`. It can also be used to define any Python method
+ * that takes no arguments and returns a string, regardless of name.
+ *
+ * @tparam PyClass The pybind11 class_ type. The wrapped class must
+ *                 support << as a stream output operator.
+ *
+ * @param cls The `PyClass` object to which to add a wrapper.
+ * @param method The name of the method to implement. Should be `"__str__"` or
+ *               `"__repr__"`.
+ */
+template <class PyClass>
+void addOutputOp(PyClass &cls, std::string const &method) {
+    cls.def(method.c_str(), [](typename PyClass::type const &self) {
+        std::ostringstream os;
+        os << self;
+        return os.str();
+    });
+}
+
+/**
 Compute a C++ index from a Python index (negative values count from the end) and range-check.
 
 @param[in] size  Number of elements in the collection.

--- a/tests/example.cc
+++ b/tests/example.cc
@@ -27,6 +27,8 @@
 #include "pybind11/operators.h"
 #include "pybind11/numpy.h"
 
+#include "lsst/utils/python.h"
+
 namespace py = pybind11;
 
 class Example {
@@ -98,8 +100,8 @@ PYBIND11_PLUGIN(_example) {
     cls.def(py::self == py::self);
     cls.def(py::self != py::self);
 
-    cls.def("__str__", [](Example &e){std::ostringstream os; os << e; return os.str();});
-    cls.def("__repr__", [](Example &e){std::ostringstream os; os << e; return os.str();});
+    lsst::utils::python::addOutputOp(cls, "__str__");
+    lsst::utils::python::addOutputOp(cls, "__repr__");
 
     mod.def("accept_float32", [](float val){return acceptNumber(val);});
     mod.def("accept_float64", [](double val){return acceptNumber(val);});


### PR DESCRIPTION
This PR adds two function templates to `utils/python.h`, one for wrapping the stream output operator as a nullary method that returns a string, and one to wrap `std::hash` as `__hash__` (the latter is technically out of scope for the ticket, but since there's only one class that specializes `std::hash` at present it didn't seem worth it to open another). Both templates are designed to not require explicit template arguments.