### PR TITLE
DM-9938: Make some afw types hashable

### DIFF
--- a/include/lsst/utils/hashCombine.h
+++ b/include/lsst/utils/hashCombine.h
@@ -66,6 +66,38 @@ std::size_t hashCombine(std::size_t seed, const T& value, Rest... rest) noexcept
     return hashCombine(seed, rest...);
 }
 
+/**
+ * Combine hashes in an iterable.
+ *
+ * This is provided as a convenience for those who need to hash a container.
+ *
+ * @tparam InputIterator an iterator to the objects to be hashed. The
+ *                       pointed-to type must have a valid (in particular,
+ *                       non-throwing) specialization of std::hash.
+ *
+ * @param seed An arbitrary starting value.
+ * @param begin, end The range to hash.
+ * @returns A combined hash for all the elements in [begin, end).
+ *
+ * @exceptsafe Shall not throw exceptions.
+ *
+ * To use it:
+ *
+ *     // Arbitrary seed; can change to get different hashes of same argument list
+ *     std::size_t seed = 0;
+ *     result = hashIterable(seed, container.begin(), container.end());
+ */
+// Note: not an overload of hashCombine to avoid ambiguity with hashCombine(size_t, T1, T2)
+// WARNING: should not be inline or constexpr; it can cause instantiation-order problems with std::hash<T>
+template <typename InputIterator>
+std::size_t hashIterable(std::size_t seed, InputIterator begin, InputIterator end) noexcept {
+    std::size_t result = 0;
+    for (; begin != end; ++begin) {
+        result = hashCombine(result, *begin);
+    }
+    return result;
+}
+
 }} // namespace lsst::utils
 
 #endif

--- a/include/lsst/utils/hashCombine.h
+++ b/include/lsst/utils/hashCombine.h
@@ -27,30 +27,44 @@
 namespace lsst {
 namespace utils {
 
-//@{
-/** Combine hashes
+/**
+ * Combine hashes
+ *
+ * A specialization of hashCombine for a trivial argument list.
+ */
+inline std::size_t hashCombine(std::size_t seed) noexcept { return seed; }
+
+/**
+ * Combine hashes
  *
  * This is provided as a convenience for those who need to hash a composite.
  * C++11 includes std::hash, but neglects to include a facility for
  * combining hashes.
  *
+ * @tparam T, Rest the types to hash. All types must have a valid (in
+ *                 particular, non-throwing) specialization of std::hash.
+ *
+ * @param seed An arbitrary starting value.
+ * @param value, rest The objects to hash.
+ * @returns A combined hash for all the arguments after `seed`.
+ *
+ * @exceptsafe Shall not throw exceptions.
+ *
  * To use it:
  *
- *    std::size_t seed = 0;
- *    result = hashCombine(seed, obj1, obj2, obj3);
- *
- * This solution is provided by Matteo Italia
- * https://stackoverflow.com/a/38140932/834250
+ *     // Arbitrary seed; can change to get different hashes of same argument list
+ *     std::size_t seed = 0;
+ *     result = hashCombine(seed, obj1, obj2, obj3);
  */
-inline std::size_t hashCombine(std::size_t seed) { return seed; }
-
+// This implementation is provided by Matteo Italia, https://stackoverflow.com/a/38140932/834250
+// Algorithm described at https://stackoverflow.com/a/27952689
+// WARNING: should not be inline or constexpr; it can cause instantiation-order problems with std::hash<T>
 template <typename T, typename... Rest>
-std::size_t hashCombine(std::size_t seed, const T& value, Rest... rest) {
+std::size_t hashCombine(std::size_t seed, const T& value, Rest... rest) noexcept {
     std::hash<T> hasher;
     seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
     return hashCombine(seed, rest...);
 }
-//@}
 
 }} // namespace lsst::utils
 

--- a/include/lsst/utils/tests.h
+++ b/include/lsst/utils/tests.h
@@ -1,0 +1,111 @@
+// -*- lsst-c++ -*-
+
+/*
+ * This file is part of utils.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_UTILS_TESTS_H
+#define LSST_UTILS_TESTS_H
+
+// Do not include unit_test.hpp, to avoid definition problems with BOOST_TEST_MODULE
+
+#include <ostream>
+#include <type_traits>
+
+namespace lsst {
+namespace utils {
+
+namespace {
+// Variable template reporting whether a type can be printed using <<
+// Second template parameter is a dummy to let us do some metaprogramming
+template <typename, typename = void>
+constexpr bool HAS_STREAM_OUTPUT = false;
+template <typename T>
+constexpr bool HAS_STREAM_OUTPUT<
+        T, std::enable_if_t<true, decltype((void)(std::declval<std::ostream&>() << std::declval<T&>()),
+                                           void())>> = true;
+
+// Conditional function templates reporting object values if possible
+template <typename T, class Hash>
+std::enable_if_t<HAS_STREAM_OUTPUT<T>> printIfHashEqual(T obj1, T obj2, Hash hash) {
+    BOOST_TEST_REQUIRE(obj1 == obj2);
+    BOOST_TEST(hash(obj1) == hash(obj2),
+               obj1 << " == " << obj2 << ", but " << hash(obj1) << " != " << hash(obj2));
+}
+template <typename T, class Hash>
+std::enable_if_t<!HAS_STREAM_OUTPUT<T>> printIfHashEqual(T obj1, T obj2, Hash hash) {
+    if (!(obj1 == obj2)) {
+        BOOST_FAIL("Unequal objects need not have equal hashes.");
+    }
+    BOOST_TEST(hash(obj1) == hash(obj2));
+}
+}  // namespace
+
+/**
+ * Compile-time test of whether a specialization of std::hash conforms to the
+ * general spec.
+ *
+ * The function itself is a no-op.
+ *
+ * @tparam T The properties of `std::hash<T>` will be tested.
+ */
+template <typename T>
+constexpr void assertValidHash() {
+    using namespace std;
+    using Hash = hash<remove_cv_t<T>>;
+
+    static_assert(is_default_constructible<Hash>::value,
+                  "std::hash specializations must be default-constructible");
+    static_assert(is_copy_assignable<Hash>::value, "std::hash specializations must be copy-assignable");
+    // Swappability hard to test before C++17
+    static_assert(is_destructible<Hash>::value, "std::hash specializations must be destructible");
+
+    static_assert(is_same<typename Hash::argument_type, remove_cv_t<T>>::value,
+                  "std::hash must have an argument_type member until C++20");
+    static_assert(is_same<typename Hash::result_type, size_t>::value,
+                  "std::hash must have a result_type member until C++20");
+    // Ability to call Hash(T) hard to test before C++17
+    static_assert(is_same<result_of_t<Hash(T)>, size_t>::value,
+                  "std::hash specializations must be callable and return a size_t");
+}
+
+/**
+ * Test that equal objects have equal hashes.
+ *
+ * If objects of type `T` can be equal despite having different internal
+ * representations, you should include pairs of such objects.
+ *
+ * @tparam T A hashable type.
+ *
+ * @param obj1, obj2 Two equal objects.
+ */
+template <typename T>
+void assertHashesEqual(T obj1, T obj2) {
+    using Hash = std::hash<std::remove_cv_t<T>>;
+
+    printIfHashEqual(obj1, obj2, Hash());
+}
+
+}  // namespace utils
+}  // namespace lsst
+
+#endif


### PR DESCRIPTION
This PR adds several extensions to the hash support added in #50.

I've added several functions for testing compliance with the `std::hash` spec. I have *not* added a hash uniformity test. I found that GCC's implementation of `std::hash<double>` fails even a very naive bitwise test, and I don't want to require that implementers of classes whose state is a single primitive jump through hoops to meet a higher standard.