### PR TITLE
DM-21314: Investigate GC problems with Storable

### DIFF
--- a/include/lsst/utils/python.h
+++ b/include/lsst/utils/python.h
@@ -151,7 +151,7 @@ inline std::pair<std::size_t, std::size_t> cppIndex(std::ptrdiff_t size_i, std::
                                                     std::ptrdiff_t i, std::ptrdiff_t j) {
     try {
         return {cppIndex(size_i, i), cppIndex(size_j, j)};
-    } catch (lsst::pex::exceptions::OutOfRangeError) {
+    } catch (lsst::pex::exceptions::OutOfRangeError const&) {
         std::ostringstream os;
         os << "Index (" << i << ", " << j << ") not in range ["
            << -size_i << ", " << size_i - 1 << "], ["

--- a/include/lsst/utils/python/PySharedPtr.h
+++ b/include/lsst/utils/python/PySharedPtr.h
@@ -1,0 +1,94 @@
+// -*- lsst-c++ -*-
+/*
+ * LSST Data Management System
+ * See COPYRIGHT file at the top of the source tree.
+ *
+ * This product includes software developed by the
+ * LSST Project (http://www.lsst.org/).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
+ * see <http://www.lsstcorp.org/LegalNotices/>.
+ */
+
+#ifndef LSST_UTILS_PYTHON_PYSHAREDPTR_H
+#define LSST_UTILS_PYTHON_PYSHAREDPTR_H
+
+#include "pybind11/pybind11.h"
+
+#include <memory>
+
+namespace lsst {
+namespace utils {
+namespace python {
+
+/* Workaround for C++ objects outliving Python objects
+ * by Xfel and florianwechsung, https://github.com/pybind/pybind11/issues/1389
+ */
+/**
+ * A shared pointer that tracks both a C++ object and its associated PyObject.
+ *
+ * Each group of PySharedPtr for a given object collectively counts as one
+ * reference to that object for the purpose of Python garbage collection.
+ *
+ * A PySharedPtr is implicitly convertible to and from a std::shared_ptr to
+ * minimize API impact. Any `shared_ptr` created this way will (I think) keep
+ * the Python reference alive, as described above.
+ */
+template <typename T>
+class PySharedPtr final {
+public:
+    using element_type = T;
+
+    /**
+     * Create a pointer that counts as an extra reference in the
+     * Python environment.
+     *
+     * @param ptr a pointer to a pybind11-managed object.
+     */
+    explicit PySharedPtr(T* const ptr) : _impl() {
+        if (ptr != nullptr) {
+            // `cast` returns new PyObject only if `*ptr` not yet associated with one
+            PyObject* pyObj = pybind11::cast(ptr).ptr();
+            Py_INCREF(pyObj);
+            // if any operation with shared_ptr fails, pyObj will get decremented correctly
+            std::shared_ptr<PyObject> manager(pyObj, [](PyObject* const obj) noexcept {
+                if (obj != nullptr) Py_DECREF(obj);
+            });
+            _impl = std::shared_ptr<T>(manager, ptr);
+        }
+    }
+
+    PySharedPtr(PySharedPtr const&) noexcept = default;
+    PySharedPtr(PySharedPtr&&) noexcept = default;
+    PySharedPtr& operator=(PySharedPtr const&) noexcept = default;
+    PySharedPtr& operator=(PySharedPtr&&) noexcept = default;
+    ~PySharedPtr() noexcept = default;
+
+    PySharedPtr(std::shared_ptr<T> r) noexcept : _impl(std::move(r)) {}
+    operator std::shared_ptr<T>() noexcept { return _impl; }
+
+    T* get() const noexcept { return _impl.get(); }
+
+private:
+    std::shared_ptr<T> _impl;
+};
+
+}  // namespace python
+}  // namespace utils
+}  // namespace lsst
+
+// Macro must be called in the global namespace
+PYBIND11_DECLARE_HOLDER_TYPE(T, lsst::utils::python::PySharedPtr<T>);
+
+#endif

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -4,5 +4,11 @@ scripts.BasicSConscript.python('_example', ['example.cc'])
 scripts.BasicSConscript.python('_backtrace', ['backtrace.cc'])
 scripts.BasicSConscript.python('_cache', ['cache.cc'])
 scripts.BasicSConscript.python('_cppIndex', ['cppIndex.cc'])
-scripts.BasicSConscript.tests(noBuildList=['example.cc', 'backtrace.cc', 'cache.cc', 'cppIndex.cc'],
+scripts.BasicSConscript.python('_inheritance', ['inheritance.cc'])
+scripts.BasicSConscript.tests(noBuildList=['example.cc',
+                                           'backtrace.cc',
+                                           'cache.cc',
+                                           'cppIndex.cc',
+                                           'inheritance.cc',
+                                           ],
                               pyList=[])

--- a/tests/inheritance.cc
+++ b/tests/inheritance.cc
@@ -1,0 +1,88 @@
+/*
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "pybind11/pybind11.h"
+
+#include <memory>
+#include <string>
+
+#include "lsst/utils/python/PySharedPtr.h"
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+
+namespace lsst {
+namespace utils {
+namespace python {
+/* Test framework based on example by cdyson37,
+ * https://github.com/pybind/pybind11/issues/1546
+ */
+
+class CppBase {
+public:
+    std::string nonOverridable() const noexcept { return "42"; }
+    virtual std::string overridable() const { return ""; }
+    virtual std::string abstract() const = 0;
+};
+
+class CppDerived : public CppBase {
+public:
+    std::string overridable() const override { return "overridden"; }
+    std::string abstract() const override { return "implemented"; }
+};
+
+template <class Base = CppBase>
+class Trampoline : public Base {
+public:
+    using Base::Base;
+
+    std::string overridable() const override { PYBIND11_OVERLOAD(std::string, Base, overridable, ); }
+    std::string abstract() const override { PYBIND11_OVERLOAD_PURE(std::string, Base, abstract, ); }
+};
+
+class CppStorage final {
+public:
+    explicit CppStorage(std::shared_ptr<CppBase> ptr) : ptr(ptr) {}
+
+    std::shared_ptr<CppBase> ptr;
+};
+
+std::shared_ptr<CppBase> getFromStorage(CppStorage const& holder) { return holder.ptr; }
+
+std::string printFromCpp(CppBase const& obj) {
+    return obj.nonOverridable() + " " + obj.overridable() + " " + obj.abstract();
+}
+
+PYBIND11_MODULE(_inheritance, mod) {
+    py::class_<CppBase, Trampoline<>, PySharedPtr<CppBase>>(mod, "CppBase").def(py::init<>());
+    py::class_<CppDerived, Trampoline<CppDerived>, CppBase, PySharedPtr<CppDerived>>(mod, "CppDerived")
+            .def(py::init<>());
+
+    py::class_<CppStorage, std::shared_ptr<CppStorage>>(mod, "CppStorage")
+            .def(py::init<std::shared_ptr<CppBase>>());
+
+    mod.def("getFromStorage", &getFromStorage, "holder"_a);
+    mod.def("printFromCpp", &printFromCpp);
+}
+
+}  // namespace python
+}  // namespace utils
+}  // namespace lsst

--- a/tests/test_pySharedPtr.py
+++ b/tests/test_pySharedPtr.py
@@ -1,0 +1,96 @@
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import gc
+import unittest
+
+import lsst.utils.tests
+import _inheritance
+
+
+class PySharedPtrTestSuite(lsst.utils.tests.TestCase):
+    """Test the ability of PySharedPtr to safely pass hybrid objects
+    between C++ and Python."""
+
+    class PyDerived(_inheritance.CppBase):
+        def __init__(self):
+            super().__init__()
+
+        # Don't override overridable()
+
+        def abstract(self):
+            return "py-abstract"
+
+    class PyCppDerived(_inheritance.CppDerived):
+        def __init__(self):
+            super().__init__()
+
+        def nonOverridable(self):
+            return "error -- should never be called!"
+
+        def overridable(self):
+            return "py-override"
+
+        def abstract(self):
+            return "py-abstract"
+
+    def checkGarbageCollection(self, concreteClass, returns):
+        """Generic test for whether a C++/Python class survives garbage collection.
+
+        Parameters
+        ----------
+        concreteClass : `_inheritance.CppBase`-type
+            The class to test. Must be default-constructible.
+        returns : `tuple`
+            A tuple of the return values from ``concreteClass``'s
+            ``nonOverridable``, ``overridable``, and ``abstract`` methods, in
+            that order.
+        """
+        storage = _inheritance.CppStorage(concreteClass())
+
+        gc.collect()
+
+        retrieved = _inheritance.getFromStorage(storage)
+        self.assertIsInstance(retrieved, _inheritance.CppBase)
+        self.assertIsInstance(retrieved, concreteClass)
+        self.assertEqual(_inheritance.printFromCpp(retrieved), " ".join(returns))
+
+    def testPyDerivedGarbageCollection(self):
+        self.checkGarbageCollection(self.PyDerived, ("42", "", "py-abstract"))
+
+    def testCppDerivedGarbageCollection(self):
+        self.checkGarbageCollection(_inheritance.CppDerived, ("42", "overridden", "implemented"))
+
+    def testPyCppDerivedGarbageCollection(self):
+        self.checkGarbageCollection(self.PyCppDerived, ("42", "py-override", "py-abstract"))
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR adds a custom holder type that blocks Python garbage collection of the associated object for the lifetime of the holder. It must be used for any class that supports Python subclasses.

Despite my best efforts, I only partially understand how `PySharedPtr` works. In particular, while I know that all C++ classes with direct Python subclasses need to use `PySharedPtr` as their holder type, I'm not sure if the same goes for their superclasses, or whether that depends on, e.g., the static types used in function signatures.