### PR TITLE
DM-23166: Add __all__ to lsst.utils.deprecated

### DIFF
--- a/python/lsst/utils/deprecated.py
+++ b/python/lsst/utils/deprecated.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__all__ = ['deprecate_pybind11', 'suppress_deprecations']
+
 import deprecated.sphinx
 import functools
 import unittest.mock


### PR DESCRIPTION
Adding an `__all__` to `lsst.utils.deprecated` is necessary to avoid failures building the Python API documentation. (otherwise, the `contextmanager` was being added to the module).

CI: https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/31066/pipeline