### PR TITLE
DM-27638: Try to ensure that previous module not found error is included

### DIFF
--- a/tests/import_test/two/three/fail.py
+++ b/tests/import_test/two/three/fail.py
@@ -1,0 +1,6 @@
+# This will fail to import because of ModuleNotFoundError
+import notthere
+
+
+def myfunc():
+    return notthere

--- a/tests/import_test/two/three/runtime.py
+++ b/tests/import_test/two/three/runtime.py
@@ -1,0 +1,3 @@
+# A module that fails to import for run time reason
+
+raise RuntimeError("This import should always fail")

--- a/tests/import_test/two/three/success.py
+++ b/tests/import_test/two/three/success.py
@@ -1,0 +1,11 @@
+# A module that always works
+
+
+def okay():
+    return True
+
+
+class Container:
+
+    def inside():
+        return "1"

--- a/tests/test_doImport.py
+++ b/tests/test_doImport.py
@@ -32,6 +32,9 @@ class ImportTestCase(lsst.utils.tests.TestCase):
         c = doImport("lsst.utils.tests.TestCase")
         self.assertEqual(c, lsst.utils.tests.TestCase)
 
+        c = doImport("lsst.utils.tests.TestCase.assertFloatsAlmostEqual")
+        self.assertEqual(c, lsst.utils.tests.TestCase.assertFloatsAlmostEqual)
+
         c = doImport("lsst.utils.doImport")
         self.assertEqual(type(c), type(doImport))
         self.assertTrue(inspect.isfunction(c))
@@ -59,6 +62,31 @@ class ImportTestCase(lsst.utils.tests.TestCase):
 
         with self.assertRaises(TypeError):
             doImport([])
+
+        # Use a special test module
+        with self.assertRaises(RuntimeError):
+            doImport("import_test.two.three.runtime")
+
+        with self.assertRaises(ImportError):
+            doImport("import_test.two.three.success.not_okay")
+
+        with self.assertRaises(ImportError):
+            doImport("import_test.two.three.fail")
+
+        # Check that the error message reports the notthere failure
+        try:
+            doImport("import_test.two.three.fail.myfunc")
+        except ImportError as e:
+            self.assertIn("notthere", str(e))
+
+        c = doImport("import_test.two.three.success")
+        self.assertTrue(c.okay())
+        c = doImport("import_test.two.three.success.okay")
+        self.assertTrue(c())
+        c = doImport("import_test.two.three.success.Container")
+        self.assertEqual(c.inside(), "1")
+        c = doImport("import_test.two.three.success.Container.inside")
+        self.assertEqual(c(), "1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since doImport treats ModuleNotFoundError as a special error
indicating that it should probably retry with a different
subset of the supplied string, this means that failures
to import dependencies trigger a confusing error report.
It's hard to disentangle real errors from dependencies
versus a request for a class within a module, so as a short
term fix include the previous import error in the final
error. Hopefully this will mitigate the problem.

Also add some explicit tests for this scenario.