### PR TITLE
DM-29701: Make version argument mandatory for deprecate_pybind11

### DIFF
--- a/python/lsst/utils/deprecated.py
+++ b/python/lsst/utils/deprecated.py
@@ -29,7 +29,7 @@ import warnings
 from contextlib import contextmanager
 
 
-def deprecate_pybind11(obj, reason, version=None, category=FutureWarning):
+def deprecate_pybind11(obj, reason, version, category=FutureWarning):
     """Deprecate a pybind11-wrapped C++ interface function, method or class.
 
     This needs to use a pass-through Python wrapper so that

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -32,10 +32,12 @@ class DeprecatedTestCase(lsst.utils.tests.TestCase):
             return x + 1
         # Use an unusual category
         old = lsst.utils.deprecate_pybind11(
-            old, reason="For testing.", category=PendingDeprecationWarning)
+            old, reason="For testing.", version="unknown",
+            category=PendingDeprecationWarning)
         with self.assertWarnsRegex(
                 PendingDeprecationWarning,
-                r"Call to deprecated function \(or staticmethod\) old\. \(For testing\.\)$"):
+                r"Call to deprecated function \(or staticmethod\) old\. \(For testing\.\) "
+                "-- Deprecated since version unknown.$"):
             # Check that the function still works
             self.assertEqual(old(3), 4)
         self.assertIn("Docstring", old.__doc__)


### PR DESCRIPTION
The deprecated.sphinx package now requires this to be set and
it seems reasonable to not have a default value here.