### PR TITLE
DM-30023: replace uncaught_exception by uncaught_exceptions

### DIFF
--- a/include/lsst/utils/python.h
+++ b/include/lsst/utils/python.h
@@ -280,7 +280,7 @@ public:
     WrapperCollection & operator=(WrapperCollection &&) = delete;
 
     ~WrapperCollection() noexcept {
-        if (!std::uncaught_exception() && !_definitions.empty()) {
+        if (std::uncaught_exceptions()==0 && !_definitions.empty()) {
             PyErr_SetString(PyExc_ImportError,
                             "WrapperCollection::finish() not called; module definition incomplete.");
             PyErr_WriteUnraisable(module.ptr());


### PR DESCRIPTION
From C++17 on bool uncaught_exception is deprecated in favor of int uncaught_exceptions