### PR TITLE
DM-31046: Add mime.cache to file leaks ignore list

### DIFF
--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -139,7 +139,9 @@ class MemoryTestCase(unittest.TestCase):
                        and not f.startswith("/proc/")
                        and not f.endswith(".ttf")
                        and not (f.startswith("/var/lib/") and f.endswith("/passwd"))
-                       and not f.endswith("astropy.log"))
+                       and not f.endswith("astropy.log")
+                       and not f.endswith("mime/mime.cache")
+                       )
 
         diff = now_open.difference(open_files)
         if diff:


### PR DESCRIPTION
I'm adding code to analysis_ap that uses PIL to open PNG images, which can leave the `mime.cache` open. We don't have control over that, so just ignore file leak failures due to this.