### PR TITLE
DM-31722a: Precursor commit to enable code coverage baseline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,10 +28,15 @@ jobs:
 
       # We have two cores so we can speed up the testing with xdist
       - name: Install pytest packages
-        run: pip install pytest pytest-flake8 pytest-xdist pytest-openfiles
+        run: pip install pytest pytest-flake8 pytest-xdist pytest-openfiles pytest-cov
 
       - name: Build and install
-        run: pip install -v .
+        run: pip install -v -e .
 
       - name: Run tests
-        run: pytest -r a -v -n 3 --open-files
+        run: pytest -r a -v -n 3 --open-files --cov=tests --cov=lsst.utils --cov-report=xml --cov-report=term
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage.xml

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ version = "0.1.0"
 with open("./python/lsst/utils/version.py", "w") as f:
     print(f"""
 __all__ = ("__version__", )
-__version__='{version}'""", file=f)
+__version__ = '{version}'""", file=f)
 
 # read the contents of our README file
 this_directory = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Making this change to ensure that we have a code coverage baseline for #100.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
