### PR TITLE
Add cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.1)
+project(utils)
+
+add_subdirectory(python/lsst/utils)

--- a/doc/changes/DM-23308.misc.rst
+++ b/doc/changes/DM-23308.misc.rst
@@ -1,0 +1,2 @@
+Add support for building via CMake in addition to eupspkg (allows inclusion as submodule into
+other CMake projects, e.g. Qserv)

--- a/python/lsst/utils/CMakeLists.txt
+++ b/python/lsst/utils/CMakeLists.txt
@@ -1,0 +1,17 @@
+find_package(pybind11 REQUIRED)
+
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/python/lsst/utils
+    FILES_MATCHING PATTERN "*.py"
+)
+
+add_custom_target(utils_version ALL
+    ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/version.py
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/version.py
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/python/lsst/utils
+)

--- a/python/lsst/utils/version.cmake
+++ b/python/lsst/utils/version.cmake
@@ -1,0 +1,27 @@
+execute_process(
+    COMMAND git describe --all --always --dirty
+    OUTPUT_VARIABLE GIT_REV
+    ERROR_QUIET
+)
+
+if("${GIT_REV}" STREQUAL "")
+    set(GIT_REV "unknown")
+endif()
+
+string(STRIP ${GIT_REV} GIT_REV)
+string(REGEX REPLACE "^(heads|tags)/" "" GIT_REV "${GIT_REV}")
+string(REPLACE "/" "_" GIT_REV "${GIT_REV}")
+
+set(VERSION_PY "__version__ = '${GIT_REV}'
+__all__ = ('__version__',)
+")
+
+if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/version.py)
+    file(READ ${CMAKE_CURRENT_BINARY_DIR}/version.py VERSION_PY_)
+else()
+    set(VERSION_PY_ "")
+endif()
+
+if(NOT "${VERSION_PY}" STREQUAL "${VERSION_PY_}")
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/version.py "${VERSION_PY}")
+endif()


### PR DESCRIPTION
Adds ability to build package with CMake in addition to eupspkg (allows to be included as submodule in other CMake projects, e.g. Qserv.)

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
