### PR TITLE
DM-32658: Only do getmodule if we know the log message will be issued

### DIFF
--- a/python/lsst/utils/timer.py
+++ b/python/lsst/utils/timer.py
@@ -306,7 +306,7 @@ def timeMethod(_func: Optional[Any] = None, *, metadata: Optional[MutableMapping
 
     def decorator_timer(func: Callable) -> Callable:
         @functools.wraps(func)
-        def wrapper(self: Any, *args: Any, **keyArgs: Any) -> Any:
+        def timeMethod_wrapper(self: Any, *args: Any, **keyArgs: Any) -> Any:
             # Adjust the stacklevel to account for the wrappers.
             # stacklevel 1 would make the log message come from this function
             # but we want it to come from the file that defined the method
@@ -320,7 +320,7 @@ def timeMethod(_func: Optional[Any] = None, *, metadata: Optional[MutableMapping
                 logInfo(obj=self, prefix=func.__name__ + "End", metadata=metadata, logger=logger,
                         logLevel=logLevel, stacklevel=stacklevel)
             return res
-        return wrapper
+        return timeMethod_wrapper
 
     if _func is None:
         return decorator_timer

--- a/python/lsst/utils/timer.py
+++ b/python/lsst/utils/timer.py
@@ -156,9 +156,12 @@ def logPairs(obj: Any, pairs: Collection[Tuple[str, Any]], logLevel: int = loggi
         strList.append(f"{name}={value}")
     if logger is not None:
         # Want the file associated with this log message to be that
-        # of the caller.
-        stacklevel = _find_outside_stacklevel()
-        logging.getLogger("timer." + logger.name).log(logLevel, "; ".join(strList), stacklevel=stacklevel)
+        # of the caller. This is expensive so only do it if we know the
+        # message will be issued.
+        timer_logger = logging.getLogger("timer." + logger.name)
+        if timer_logger.isEnabledFor(logLevel):
+            stacklevel = _find_outside_stacklevel()
+            timer_logger.log(logLevel, "; ".join(strList), stacklevel=stacklevel)
 
 
 def logInfo(obj: Any, prefix: str, logLevel: int = logging.DEBUG,


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
