### PR TITLE
DM-32682: Fix metadata.add fallback code

### DIFF
--- a/python/lsst/utils/timer.py
+++ b/python/lsst/utils/timer.py
@@ -60,7 +60,7 @@ def _add_to_metadata(metadata: MutableMapping, name: str, value: Any) -> None:
         try:
             # PropertySet should always prefer LongLong for integers
             metadata.addLongLong(name, value)  # type: ignore
-        except TypeError:
+        except (TypeError, AttributeError):
             metadata.add(name, value)  # type: ignore
     except AttributeError:
         pass


### PR DESCRIPTION
Previously failing to call `addLongDouble()` never triggered the call to `.add()`

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
