### PR TITLE
DM-20970: Fix units in max_rss field for logInfo

### DIFF
--- a/doc/changes/DM-20970.api.rst
+++ b/doc/changes/DM-20970.api.rst
@@ -1,0 +1,2 @@
+The values for max resident set size stored in metadata are now consistently reported as bytes.
+Previously the units were platform specific (kibibytes on Liux and bytes on macOS).

--- a/doc/lsst.utils/index.rst
+++ b/doc/lsst.utils/index.rst
@@ -48,3 +48,5 @@ Python API reference
    :no-main-docstr:
 .. automodapi:: lsst.utils.packages
    :no-main-docstr:
+.. automodapi:: lsst.utils.usage
+   :no-main-docstr:

--- a/python/lsst/utils/usage.py
+++ b/python/lsst/utils/usage.py
@@ -40,8 +40,9 @@ def get_current_mem_usage() -> Tuple[u.Quantity, u.Quantity]:
     not reflect the actual memory allocated to the process and its children.
     """
     proc = psutil.Process()
-    usage_main = proc.memory_info().rss * u.byte
-    usage_child = sum([child.memory_info().rss for child in proc.children()]) * u.byte
+    with proc.oneshot():
+        usage_main = proc.memory_info().rss * u.byte
+        usage_child = sum([child.memory_info().rss for child in proc.children()]) * u.byte
     return usage_main, usage_child
 
 

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -91,6 +91,8 @@ class TestTimeMethod(unittest.TestCase):
             logInfo(None, prefix="Prefix", metadata=metadata, logger=logger, logLevel=logging.INFO)
         self.assertEqual(cm.records[0].filename, THIS_FILE)
         self.assertIn("PrefixUtc", metadata)
+        self.assertIn("PrefixMaxResidentSetSize", metadata)
+        self.assertEqual(metadata["__version__"], 1)
 
         # Again with no log output.
         logInfo(None, prefix="Prefix", metadata=metadata)


### PR DESCRIPTION
This moves the `getrusage` code from timer.py into usage.py and ensures that the units are in bytes.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
