### PR TITLE
DM-34386: Improve doImport error message.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python

--- a/python/lsst/utils/doImport.py
+++ b/python/lsst/utils/doImport.py
@@ -83,7 +83,9 @@ def doImport(importable: str) -> Union[types.ModuleType, Type]:
             # Move element from module to file and try again
             infileComponents.insert(0, moduleComponents.pop())
 
-    raise ModuleNotFoundError(f"Unable to import {importable}")
+    # Fell through without success.
+    extra = f"({previousError})" if previousError is not None else ""
+    raise ModuleNotFoundError(f"Unable to import {importable!r} {extra}")
 
 
 def doImportType(importable: str) -> Type:


### PR DESCRIPTION
Rather than:

```
Unable to import "lsst.utils.version.__version__"
```
instead
```
Unable to import '"lsst.utils.version.__version__"' (No module named '"lsst')
```

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
