### PR TITLE
DM-36116: Add docs for ellipsis workaround.

### DIFF
--- a/doc/lsst.utils/index.rst
+++ b/doc/lsst.utils/index.rst
@@ -52,3 +52,4 @@ Python API reference
    :no-main-docstr:
 .. automodapi:: lsst.utils.threads
    :no-main-docstr:
+.. automodapi:: lsst.utils.ellipsis

--- a/python/lsst/utils/ellipsis.py
+++ b/python/lsst/utils/ellipsis.py
@@ -9,6 +9,28 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
+"""
+A type-annotation workaround for ``...`` not having an exposed type in Python.
+
+This module provides ``Ellipsis`` and ``EllipsisType`` symbols that are
+conditionally defined to point to the built-in "``...``" singleton and its type
+(respectively) at runtime, and an enum class and instance if
+`typing.TYPE_CHECKING` is `True` (an approach first suggested
+`here <https://github.com/python/typing/issues/684#issuecomment-548203158>`_).
+Type checkers should recognize enum literals as singletons, making this pair
+behave as expected under ``is`` comparisons and type-narrowing expressions,
+such as::
+
+    v: EllipsisType | int
+    if v is not Ellipsis:
+        v += 2  # type checker should now see v as a pure int
+
+This works best when there is a clear boundary between code that needs to be
+type-checked and can use  ``Ellipsis`` instead of a literal "``...``", and
+calling code that is either not type-checked or uses `typing.Any` to accept
+literal "``...``" values.
+"""
+
 from __future__ import annotations
 
 __all__ = ("Ellipsis", "EllipsisType")
@@ -16,16 +38,7 @@ __all__ = ("Ellipsis", "EllipsisType")
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    # Workaround for `...` not having an exposed type in Python, borrowed from
-    # https://github.com/python/typing/issues/684#issuecomment-548203158
-    # Along with that, we need to either use `Ellipsis` instead of `...` for
-    # the actual sentinal value internally, and tell MyPy to ignore conversions
-    # from `...` to `Ellipsis` at the public-interface boundary.
-    #
-    # `Ellipsis` and `EllipsisType` should be directly imported from this
-    # module by related code that needs them; hopefully that will stay confined
-    # to `lsst.daf.butler.registry`.  Putting these in __all__ is bad for
-    # Sphinx, and probably more confusing than helpful overall.
+
     from enum import Enum
 
     class EllipsisType(Enum):

--- a/python/lsst/utils/ellipsis.py
+++ b/python/lsst/utils/ellipsis.py
@@ -47,5 +47,9 @@ if TYPE_CHECKING:
     Ellipsis = EllipsisType.Ellipsis
 
 else:
-    EllipsisType = type(Ellipsis)
+    try:
+        # Present in Python >= 3.10
+        from types import EllipsisType
+    except ImportError:
+        EllipsisType = type(Ellipsis)
     Ellipsis = Ellipsis


### PR DESCRIPTION
This replaces an outdated code comment with a module docstring, since it doesn't look possible to actually document the symbols exported by this module.

## Checklist

- [ ] ran Jenkins
- [ ] ~added a release note for user-visible changes to `doc/changes`~: I don't think it's user-visibly distinct from DM-36108.
