### PR TITLE
DM-38587: Do not gather memory statistics if the log message will not be issued

### DIFF
--- a/doc/changes/DM-38587.bugfix.rst
+++ b/doc/changes/DM-38587.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``time_this`` when ``mem_usage=True`` to prevent memory statistics being gathered when the log message would not be issued.
+We had been trapping this on the exit to the context manager but not entry for the initial memory statistics gathering.

--- a/python/lsst/utils/timer.py
+++ b/python/lsst/utils/timer.py
@@ -415,6 +415,10 @@ def time_this(
 
     success = False
     start = time.time()
+
+    if mem_usage and not log.isEnabledFor(level):
+        mem_usage = False
+
     if mem_usage:
         current_usages_start = get_current_mem_usage()
         peak_usages_start = get_peak_mem_usage()
@@ -444,7 +448,7 @@ def time_this(
         # caller (1 is this file, 2 is contextlib, 3 is user)
         params += (": " if msg else "", end - start)
         msg += "%sTook %.4f seconds"
-        if mem_usage and log.isEnabledFor(level):
+        if mem_usage:
             current_usages_end = get_current_mem_usage()
             peak_usages_end = get_peak_mem_usage()
 

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -207,6 +207,19 @@ class TimerTestCase(unittest.TestCase):
         self.assertIn("peak delta", cm.output[0])
         self.assertIn("byte", cm.output[0])
 
+        # Request memory usage but with log level that will not issue it.
+        with self.assertLogs(level="INFO") as cm:
+            with time_this(level=logging.DEBUG, prefix=None, mem_usage=True):
+                pass
+            # Ensure that a log message is issued.
+            _log = logging.getLogger()
+            _log.info("info")
+        self.assertEqual(cm.records[0].name, "root")
+        self.assertEqual(cm.records[0].levelname, "INFO")
+        all = "\n".join(cm.output)
+        self.assertNotIn("Took", all)
+        self.assertNotIn("memory", all)
+
         # Report memory usage including child processes.
         with self.assertLogs(level="DEBUG") as cm:
             with time_this(level=logging.DEBUG, prefix=None, mem_usage=True, mem_child=True):


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
