### PR TITLE
DM-38665: No longer use assert for python version mismatch

### DIFF
--- a/doc/changes/DM-38665.bugfix.md
+++ b/doc/changes/DM-38665.bugfix.md
@@ -1,0 +1,2 @@
+Updated the python version handling such that it is no longer a failure for the python package version to disagree with the `.version` property of that package.
+The package version is now used in preference if there is a disagreement.


### PR DESCRIPTION
We can't actually guarantee that the ._version matches the parent version (it doesn't for pooch) so instead assume that the parent version is always right if there is a real mismatch.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
