### PR TITLE
DM-38812: Prefer using importlib.metadata rather than __version__

### DIFF
--- a/doc/changes/DM-38812.misc.rst
+++ b/doc/changes/DM-38812.misc.rst
@@ -1,0 +1,2 @@
+Modified the code that determines the versions of Python packages so that it now uses `importlib.metadata`.
+This is slightly slower than accessing ``__version__`` but does give more consistent results.

--- a/python/lsst/utils/packages.py
+++ b/python/lsst/utils/packages.py
@@ -118,11 +118,17 @@ def getPythonPackages() -> Dict[str, str]:
     # subject to race conditions
     moduleNames = list(sys.modules.keys())
     for name in moduleNames:
-        module = sys.modules[name]
         try:
-            ver = getVersionFromPythonModule(module)
+            # This is the Python standard way to find a package version.
+            # It can be slow.
+            ver = importlib.metadata.version(name)
         except Exception:
-            continue  # Can't get a version from it, don't care
+            # Fall back to using the module itself.
+            module = sys.modules[name]
+            try:
+                ver = getVersionFromPythonModule(module)
+            except Exception:
+                continue  # Can't get a version from it, don't care
 
         # Remove "foo.bar.version" in favor of "foo.bar"
         # This prevents duplication when the __init__.py includes


### PR DESCRIPTION
For example jsonschema has decided to no longer support `__version__` and wants to use importlib.metadata.

The downside of this is that importlib.metadata is much slower than asking for the `__version__` of a module that's already imported. Hundreds of milliseconds vs microseconds to get the package versions and importlib.metadata does not seem to cache the result.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
