### PR TITLE
DM-38815: Add one more variable to set in `set_thread_envvars`

### DIFF
--- a/python/lsst/utils/threads.py
+++ b/python/lsst/utils/threads.py
@@ -50,6 +50,12 @@ def set_thread_envvars(num_threads: int = 1, override: bool = False) -> None:
         if override or var not in os.environ:
             os.environ[var] = str(num_threads)
 
+    # Also specify an explicit value for OMP_PROC_BIND to tell OpenMP not to
+    # set CPU affinity.
+    var = "OMP_PROC_BIND"
+    if override or var not in os.environ:
+        os.environ[var] = "false"
+
 
 def disable_implicit_threading() -> None:
     """Do whatever is necessary to try to prevent implicit threading.

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -36,6 +36,7 @@ class ThreadsTestCase(unittest.TestCase):
 
         disable_implicit_threading()
         self.assertEqual(os.environ["OMP_NUM_THREADS"], "1")
+        self.assertEqual(os.environ["OMP_PROC_BIND"], "false")
 
         # Check that we have only one thread.
         if numexpr:


### PR DESCRIPTION
When set to "false" the envvar `OMP_PROC_BIND` should stop OpenMP from setting CPU affinity.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
