### PR TITLE
DM-39402: Refactor python package determination to use a hierarchy

### DIFF
--- a/doc/changes/DM-39402.misc.rst
+++ b/doc/changes/DM-39402.misc.rst
@@ -1,0 +1,2 @@
+Improved the performance of ``lsst.utils.packages.getPythonPackages()`` to use the namespace hierarchy so it now only needs to check as deep into the hierarchy as is needed to find a version.
+Additionally, the code no longer tries to extract versions from Python standard library packages.

--- a/python/lsst/utils/packages.py
+++ b/python/lsst/utils/packages.py
@@ -204,29 +204,6 @@ def _get_python_package_version(name: str, packages: dict[str, str]) -> tuple[st
         except Exception:
             return name, None  # Can't get a version from it, don't care
 
-    # Remove "foo.bar.version" in favor of "foo.bar"
-    # This prevents duplication when the __init__.py includes
-    # "from .version import *"
-    modified = False
-    for ending in (".version", "._version"):
-        if name.endswith(ending):
-            name = name[: -len(ending)]
-            modified = True
-            break
-
-    # Check if this name has already been registered.
-    # This can happen if x._version is encountered before x.
-    if name in packages:
-        if ver != packages[name]:
-            # There is an inconsistency between this version
-            # and that previously calculated. Raising an exception
-            # would go against the ethos of this package. If this
-            # is the stripped package name we should drop it and
-            # trust the primary version. Else if this was not
-            # the modified version we should use it in preference.
-            if modified:
-                return name, None
-
     # Update the package information.
     if ver is not None:
         packages[name] = ver

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -112,22 +112,22 @@ class PackagesTestCase(unittest.TestCase):
         # Now load an obscure python package and the list of packages should
         # change
         # Shouldn't be used by anything we've previously imported
-        import smtpd  # noqa: F401
+        import chunk  # noqa: F401
 
         new = lsst.utils.packages.Packages.fromSystem()
         self.assertDictEqual(packages.difference(new), {})  # No inconsistencies
         self.assertDictEqual(packages.extra(new), {})  # Nothing in 'packages' that's not in 'new'
         missing = packages.missing(new)
         self.assertGreater(len(missing), 0)  # 'packages' should be missing some stuff in 'new'
-        self.assertIn("smtpd", missing)
+        self.assertIn("chunk", missing)
 
         # Inverted comparisons
         self.assertDictEqual(new.difference(packages), {})
         self.assertDictEqual(new.missing(packages), {})  # Nothing in 'new' that's not in 'packages'
         extra = new.extra(packages)
         self.assertGreater(len(extra), 0)  # 'new' has extra stuff compared to 'packages'
-        self.assertIn("smtpd", extra)
-        self.assertIn("smtpd", new)
+        self.assertIn("chunk", extra)
+        self.assertIn("chunk", new)
 
         # Run with both a Packages and a dict
         for new_pkg in (new, dict(new)):


### PR DESCRIPTION
Using `importlib.metadata.version` can be slow so using it for "a.b.c" and "a.b.c.d1" and "a.b.c.d2" when we know the version of "a.b.c" is wasteful. Use the hierarchy to minimize the number of version requests. Also skip standard library modules.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
