### PR TITLE
DM-40367: Record stack information in find_outside_stacklevel call

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,11 +27,12 @@ jobs:
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true
+          miniforge-variant: Mambaforge
+          use-mamba: true
 
       - name: Install eups and any other conda packages
         shell: bash -l {0}
         run: |
-          conda install mamba
           mamba install -y -q eups conda pip
 
       # We have two cores so we can speed up the testing with xdist
@@ -57,7 +58,7 @@ jobs:
 
       - name: Build and install
         shell: bash -l {0}
-        run: pip install -v -e .
+        run: pip install --no-deps -v -e .
 
       - name: Setup EUPS test package
         shell: bash -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.10
+        language_version: python3.11
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/doc/changes/DM-40367.feature.rst
+++ b/doc/changes/DM-40367.feature.rst
@@ -1,0 +1,2 @@
+Added the ability for ``find_outside_stacklevel`` to return additional information about the matching stack to the caller.
+This allows, for example, the filename and lineno to be reported without the caller making another call to ``inspect.stack()`` or calling ``get_caller_name``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ version = { attr = "lsst_versions.get_lsst_version" }
 
 [tool.black]
 line-length = 110
-target-version = ["py310"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"
@@ -152,7 +152,7 @@ select = [
     "W",  # pycodestyle
     "D",  # pydocstyle
 ]
-target-version = "py310"
+target-version = "py311"
 extend-select = [
     "RUF100", # Warn about unused noqa
 ]

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -125,6 +125,10 @@ class TestInstropection(unittest.TestCase):
         level = find_outside_stacklevel("lsst.utils")
         self.assertEqual(level, 1)
 
+        info = {}
+        level = find_outside_stacklevel("lsst.utils", stack_info=info)
+        self.assertIn("test_introspection.py", info["filename"])
+
         c = doImport("import_test.two.three.success.Container")
         with self.assertWarns(Warning) as cm:
             level = c.level()


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
