### PR TITLE
DM-40803: Change how conda list is run

### DIFF
--- a/doc/changes/DM-40803.misc.rst
+++ b/doc/changes/DM-40803.misc.rst
@@ -1,0 +1,2 @@
+Changed how Conda package versions are discovered, resulting in a 10x speed up.
+No longer uses ``conda list``.

--- a/python/lsst/utils/packages.py
+++ b/python/lsst/utils/packages.py
@@ -344,7 +344,10 @@ def getCondaPackages() -> dict[str, str]:
     # packages.
     meta_path = os.path.join(os.environ["CONDA_PREFIX"], "conda-meta")
 
-    filenames = os.scandir(path=meta_path)
+    try:
+        filenames = os.scandir(path=meta_path)
+    except FileNotFoundError:
+        return {}
 
     packages = {}
 

--- a/python/lsst/utils/packages.py
+++ b/python/lsst/utils/packages.py
@@ -336,11 +336,17 @@ def getCondaPackages() -> dict[str, str]:
     Returns empty result if a conda environment is not in use or can not
     be queried.
     """
-    # Get the installed package list
+    # Require the conda API to list conda packages.
     try:
-        versions_json = subprocess.check_output(["conda", "list", "--json"])
-    except subprocess.CalledProcessError:
+        from conda.cli.main import main_subshell
+    except ImportError:
+        # Assume no conda packages.
         return {}
+
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        main_subshell("list", "--json")
+    versions_json = stdout.getvalue()
 
     packages = {pkg["name"]: pkg["version"] for pkg in json.loads(versions_json)}
 

--- a/python/lsst/utils/packages.py
+++ b/python/lsst/utils/packages.py
@@ -336,21 +336,18 @@ def getCondaPackages() -> dict[str, str]:
     Returns empty result if a conda environment is not in use or can not
     be queried.
     """
+    # Get the installed package list
     try:
-        from conda.cli.python_api import Commands, run_command
-    except ImportError:
+        versions_json = subprocess.check_output(["conda", "list", "--json"])
+    except subprocess.CalledProcessError:
         return {}
 
-    # Get the installed package list
-    versions_json = run_command(Commands.LIST, "--json")
-    packages = {pkg["name"]: pkg["version"] for pkg in json.loads(versions_json[0])}
+    packages = {pkg["name"]: pkg["version"] for pkg in json.loads(versions_json)}
 
     # Try to work out the conda environment name and include it as a fake
     # package. The "obvious" way of running "conda info --json" does give
     # access to the active_prefix but takes about 2 seconds to run.
-    # The equivalent to the code above would be:
-    #    info_json = run_command(Commands.INFO, "--json")
-    # As a comporomise look for the env name in the path to the python
+    # As a compromise look for the env name in the path to the python
     # executable
     match = re.search(r"/envs/(.*?)/bin/", sys.executable)
     if match:

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -11,5 +11,13 @@
 # Use of this source code is governed by a 3-clause BSD-style
 # license that can be found in the LICENSE file.
 
-from lsst.sconsUtils import scripts
+import os
+
+from lsst.sconsUtils import env, scripts
+
 scripts.BasicSConscript.tests(pyList=[])
+
+# The test does not rely on this environment variable being set but
+# if it is set then additional code paths are covered.
+if (envvar := "CONDA_PREFIX") in os.environ:
+    env["ENV"][envvar] = os.environ[envvar]


### PR DESCRIPTION
conda.cli.python_api has been deprecated and the suggested replacement is intended solely for test code. Given that the original conda API was using subprocess to run conda list and not using any internal conda APIs, call conda list ourselves.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
