### PR TITLE
DM-42317: Make Singleton threadsafe

### DIFF
--- a/doc/changes/DM-42317.bugfix.rst
+++ b/doc/changes/DM-42317.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a race condition in ``Singleton`` that could cause more than one instance of a class to be created if two threads concurrently attempted to create the instance.


### PR DESCRIPTION
Previously, if there were multiple threads concurrently calling a constructor for a Singleton class, you could end up instantiating more than one instance of the class.  daf_butler classes using this metaclass are used in a multi-threaded context.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
