### PR TITLE
DM-45007: Add simple memory profiling tools

### DIFF
--- a/doc/changes/DM-45007.feature.md
+++ b/doc/changes/DM-45007.feature.md
@@ -1,0 +1,1 @@
+Added `lsst.utils.introspection.take_object_census` function for characterizing memory leaks.

--- a/doc/changes/DM-45007.feature.md
+++ b/doc/changes/DM-45007.feature.md
@@ -1,1 +1,1 @@
-Added `lsst.utils.introspection.take_object_census` function for characterizing memory leaks.
+Added `lsst.utils.introspection.take_object_census` and `lsst.utils.introspection.trace_object_references` functions for characterizing memory leaks.

--- a/doc/changes/README.rst
+++ b/doc/changes/README.rst
@@ -17,7 +17,5 @@ The ``<TYPE>`` should be one of:
 
 An example file name would therefore look like ``DM-30291.misc.rst``.
 
-If the change concerns specifically the registry or a datastore the news fragment can be placed in the relevant subdirectory.
-
 You can test how the content will be integrated into the release notes by running ``towncrier --draft --version=V.vv``.
 ``towncrier`` can be installed from PyPI or conda-forge.

--- a/python/lsst/utils/introspection.py
+++ b/python/lsst/utils/introspection.py
@@ -19,9 +19,12 @@ __all__ = [
     "get_instance_of",
     "get_caller_name",
     "find_outside_stacklevel",
+    "take_object_census",
 ]
 
 import builtins
+import collections
+import gc
 import inspect
 import sys
 import types
@@ -301,3 +304,26 @@ def find_outside_stacklevel(
         stacklevel = i
 
     return stacklevel
+
+
+def take_object_census() -> collections.Counter[type]:
+    """Count the number of existing objects, by type.
+
+    The census is returned as a `~collections.Counter` object. Expected usage
+    involves taking the difference with a different `~collections.Counter` and
+    examining any changes.
+
+    Returns
+    -------
+    census : `collections.Counter` [`type`]
+        The number of objects found of each type.
+
+    Notes
+    -----
+    This function counts _all_ Python objects in memory. To count only
+    reachable objects, run `gc.collect` first.
+    """
+    counts: collections.Counter[type] = collections.Counter()
+    for obj in gc.get_objects():
+        counts[type(obj)] += 1
+    return counts

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -33,6 +33,7 @@ from lsst.utils.introspection import (
     get_class_of,
     get_full_type_name,
     get_instance_of,
+    take_object_census,
 )
 
 
@@ -166,6 +167,18 @@ class TestInstropection(unittest.TestCase):
             level = c.indirect_level(allow_methods=allow_methods)
         self.assertEqual(level, stacklevel)
         self.assertTrue(cm.filename.endswith("success.py"))
+
+    def test_take_object_census(self):
+        # Full output cannot be validated, because it depends on the global
+        # state of the test process.
+        class DummyClass:
+            pass
+
+        dummy = DummyClass()  # noqa: F841, unused variable
+
+        counts = take_object_census()
+        self.assertIsInstance(counts, Counter)
+        self.assertEqual(counts[DummyClass], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a couple of simple tools that were developed for investigating [DM-45007](https://rubinobs.atlassian.net/browse/DM-45007).

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`


[DM-45007]: https://rubinobs.atlassian.net/browse/DM-45007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ