### PR TITLE
DM-47310: Fix time_this code if error message includes % formatting character

### DIFF
--- a/python/lsst/utils/timer.py
+++ b/python/lsst/utils/timer.py
@@ -401,7 +401,8 @@ def time_this(
         params += (": " if msg else "", end - start)
         msg += "%sTook %.4f seconds"
         if errmsg:
-            msg += f" (timed code triggered exception of {errmsg!r})"
+            params += (f" (timed code triggered exception of {errmsg!r})",)
+            msg += "%s"
         if mem_usage:
             current_usages_end = get_current_mem_usage()
             peak_usages_end = get_peak_mem_usage()

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -316,9 +316,9 @@ class TimerTestCase(unittest.TestCase):
         with self.assertLogs(level="DEBUG") as cm:
             with self.assertRaises(RuntimeError):
                 with time_this(log=logging.getLogger(logname), prefix=prefix):
-                    raise RuntimeError("A problem")
+                    raise RuntimeError("A problem %s")
         self.assertEqual(cm.records[0].name, f"{prefix}.{logname}")
-        self.assertIn("A problem", cm.records[0].message)
+        self.assertIn("A problem %s", cm.records[0].message)
         self.assertEqual(cm.records[0].levelname, "DEBUG")
 
 


### PR DESCRIPTION
Jenkins doesn't test the butler server code and server URLs can include `%` which broke before this fix.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
