### PR TITLE
DM-46249-hotfix3 : Upload analysis_tools metrics from ap_verify so they can be retrieved in Chronograf

### DIFF
--- a/doc/changes/DM-46249.feature.rst
+++ b/doc/changes/DM-46249.feature.rst
@@ -1,0 +1,1 @@
+Added ``lsst.utils.argparsing.AppendDict``, inherits from `argparsing.Action`. This utility for argument parsing enables multiple optional parameters in command line interfaces. It receives `key-value` parameters and parses them to a dictionary.

--- a/python/lsst/utils/__init__.py
+++ b/python/lsst/utils/__init__.py
@@ -11,6 +11,7 @@
 """General LSST Utilities."""
 
 from ._packaging import *
+from .argparsing import *
 from .deprecated import *
 from .doImport import *
 from .inheritDoc import *

--- a/python/lsst/utils/__init__.py
+++ b/python/lsst/utils/__init__.py
@@ -11,7 +11,6 @@
 """General LSST Utilities."""
 
 from ._packaging import *
-from .argparsing import *
 from .deprecated import *
 from .doImport import *
 from .inheritDoc import *

--- a/python/lsst/utils/argparsing.py
+++ b/python/lsst/utils/argparsing.py
@@ -19,6 +19,7 @@ __all__ = ["AppendDict"]
 import argparse
 import copy
 from collections.abc import Mapping
+from typing import Any
 
 
 class AppendDict(argparse.Action):
@@ -33,16 +34,16 @@ class AppendDict(argparse.Action):
 
     def __init__(
         self,
-        option_strings,
-        dest,
-        nargs=None,
-        const=None,
-        default=None,
-        type=None,
-        choices=None,
-        required=False,
-        help=None,
-        metavar=None,
+        option_strings: str | list[str],
+        dest: str,
+        nargs: int | str | None = None,
+        const: Any | None = None,
+        default: Any | None = None,
+        type: type | None = None,
+        choices: Any | None = None,
+        required: bool = False,
+        help: str | None = None,
+        metavar: str | None = None,
     ):
         if default is None:
             default = {}
@@ -51,7 +52,9 @@ class AppendDict(argparse.Action):
             raise TypeError(f"Default for {argname} must be a mapping or None, got {default!r}.")
         super().__init__(option_strings, dest, nargs, const, default, type, choices, required, help, metavar)
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(
+        self, parser: argparse.ArgumentParser, namespace: Any, values: Any, option_string: str | None = None
+    ) -> None:
         # argparse doesn't make defensive copies, so namespace.dest may be
         # the same object as self.default. Do the copy ourselves and avoid
         # modifying the object previously in namespace.dest.

--- a/python/lsst/utils/argparsing.py
+++ b/python/lsst/utils/argparsing.py
@@ -1,0 +1,76 @@
+# This file is part of utils.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# Use of this source code is governed by a 3-clause BSD-style
+# license that can be found in the LICENSE file.
+#
+
+"""Utilities to help with argument parsing in command line interfaces."""
+
+from __future__ import annotations
+
+__all__ = ["AppendDict"]
+
+import argparse
+import copy
+from collections.abc import Mapping
+
+
+class AppendDict(argparse.Action):
+    """An action analogous to the build-in 'append' that appends to a `dict`
+    instead of a `list`.
+
+    Inputs are assumed to be strings in the form "key=value"; any input that
+    does not contain exactly one "=" character is invalid. If the default value
+    is non-empty, the default key-value pairs may be overwritten by values from
+    the command line.
+    """
+
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        nargs=None,
+        const=None,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
+        if default is None:
+            default = {}
+        if not isinstance(default, Mapping):
+            argname = option_strings if option_strings else metavar if metavar else dest
+            raise TypeError(f"Default for {argname} must be a mapping or None, got {default!r}.")
+        super().__init__(option_strings, dest, nargs, const, default, type, choices, required, help, metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        # argparse doesn't make defensive copies, so namespace.dest may be
+        # the same object as self.default. Do the copy ourselves and avoid
+        # modifying the object previously in namespace.dest.
+        mapping = copy.copy(getattr(namespace, self.dest))
+
+        # Sometimes values is a copy of default instead of an input???
+        if isinstance(values, Mapping):
+            mapping.update(values)
+        else:
+            # values may be either a string or list of strings, depending on
+            # nargs. Unsafe to test for Sequence, because a scalar string
+            # passes.
+            if not isinstance(values, list):
+                values = [values]
+            for value in values:
+                vars = value.split("=")
+                if len(vars) != 2:
+                    raise ValueError(f"Argument {value!r} does not match format 'key=value'.")
+                mapping[vars[0]] = vars[1]
+
+        # Other half of the defensive copy.
+        setattr(namespace, self.dest, mapping)

--- a/python/lsst/utils/argparsing.py
+++ b/python/lsst/utils/argparsing.py
@@ -23,7 +23,7 @@ from typing import Any
 
 
 class AppendDict(argparse.Action):
-    """An action analogous to the build-in 'append' that appends to a `dict`
+    """An action analogous to the built-in 'append' that appends to a `dict`
     instead of a `list`.
 
     Inputs are assumed to be strings in the form "key=value"; any input that

--- a/tests/test_argparsing.py
+++ b/tests/test_argparsing.py
@@ -1,0 +1,130 @@
+# This file is part of utils.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import argparse
+import logging
+import unittest
+
+from lsst.utils.argparsing import AppendDict
+
+log = logging.getLogger("test_argparsing")
+
+
+class AppendDictTestSuite(unittest.TestCase):
+    """Test suite for AppendDict action."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.testbed = argparse.ArgumentParser()
+
+    def test_default_none_positional(self):
+        self.testbed.add_argument("test", action=AppendDict, nargs="*")
+
+        namespace = self.testbed.parse_args([])
+        self.assertEqual(namespace.test, {})
+
+        namespace = self.testbed.parse_args("baz=bak".split())
+        self.assertEqual(namespace.test, {"baz": "bak"})
+
+    def test_default_none_keyword(self):
+        self.testbed.add_argument("--test", action=AppendDict)
+
+        namespace = self.testbed.parse_args([])
+        self.assertEqual(namespace.test, {})
+
+        namespace = self.testbed.parse_args("--test baz=bak".split())
+        self.assertEqual(namespace.test, {"baz": "bak"})
+
+    def test_default_empty_positional(self):
+        self.testbed.add_argument("test", action=AppendDict, default={}, nargs="*")
+
+        namespace = self.testbed.parse_args([])
+        self.assertEqual(namespace.test, {})
+
+        namespace = self.testbed.parse_args("baz=bak".split())
+        self.assertEqual(namespace.test, {"baz": "bak"})
+
+    def test_default_empty_keyword(self):
+        self.testbed.add_argument("--test", action=AppendDict, default={})
+
+        namespace = self.testbed.parse_args([])
+        self.assertEqual(namespace.test, {})
+
+        namespace = self.testbed.parse_args("--test baz=bak".split())
+        self.assertEqual(namespace.test, {"baz": "bak"})
+
+    def test_default_non_empty_positional(self):
+        self.testbed.add_argument("test", action=AppendDict, default={"foo": "bar"}, nargs="*")
+
+        namespace = self.testbed.parse_args([])
+        self.assertEqual(namespace.test, {"foo": "bar"})
+
+        namespace = self.testbed.parse_args("baz=bak".split())
+        self.assertEqual(namespace.test, {"foo": "bar", "baz": "bak"})
+
+        namespace = self.testbed.parse_args("foo=fum".split())
+        self.assertEqual(namespace.test, {"foo": "fum"})
+
+    def test_default_non_empty_keyword(self):
+        self.testbed.add_argument("--test", action=AppendDict, default={"foo": "bar"})
+
+        namespace = self.testbed.parse_args([])
+        self.assertEqual(namespace.test, {"foo": "bar"})
+
+        namespace = self.testbed.parse_args("--test baz=bak".split())
+        self.assertEqual(namespace.test, {"foo": "bar", "baz": "bak"})
+
+        namespace = self.testbed.parse_args("--test foo=fum".split())
+        self.assertEqual(namespace.test, {"foo": "fum"})
+
+    def test_default_invalid(self):
+        with self.assertRaises(TypeError):
+            self.testbed.add_argument("test", action=AppendDict, default="bovine")
+        with self.assertRaises(TypeError):
+            self.testbed.add_argument("test", action=AppendDict, default=[])
+
+    def test_multi_append(self):
+        self.testbed.add_argument("--test", action=AppendDict)
+
+        namespace = self.testbed.parse_args("--test foo=bar --test baz=bak".split())
+        self.assertEqual(namespace.test, {"foo": "bar", "baz": "bak"})
+
+    def test_multi_nargs_append(self):
+        self.testbed.add_argument("--test", action=AppendDict, nargs="*")
+
+        namespace = self.testbed.parse_args("--test foo=bar fee=fum --test baz=bak --test".split())
+        self.assertEqual(namespace.test, {"foo": "bar", "fee": "fum", "baz": "bak"})
+
+    def test_emptyvalue(self):
+        self.testbed.add_argument("test", action=AppendDict)
+
+        namespace = self.testbed.parse_args("foo=".split())
+        self.assertEqual(namespace.test, {"foo": ""})
+
+    def test_nopair(self):
+        self.testbed.add_argument("test", action=AppendDict)
+
+        with self.assertRaises(ValueError):
+            self.testbed.parse_args("foo".split())
+
+        with self.assertRaises(ValueError):
+            self.testbed.parse_args("assertion=beauty=truth".split())


### PR DESCRIPTION
Add a new module, with argparsing tools. In particular class `AppendDict` to handle multiple optional keyword value inputs in cli scripts.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
