### PR TITLE
SITCOM-1862: Create standard matplotlib style for System First Light construction paper

### DIFF
--- a/python/lsst/utils/plotting/__init__.py
+++ b/python/lsst/utils/plotting/__init__.py
@@ -12,3 +12,4 @@
 
 from .figures import *
 from .limits import *
+from .publication_plots import *

--- a/python/lsst/utils/plotting/figures.py
+++ b/python/lsst/utils/plotting/figures.py
@@ -142,7 +142,14 @@ def get_multiband_plot_linestyles() -> dict:
         "g": ":",
         "r": "-",
         "i": "-.",
-        "z": (0, (3, 5, 1, 5, 1, 5)),
-        "y": (0, (3, 1, 1, 1)),
+        "z": "--",
+        "y": ":",
     }
+
+    # Note, Mar. 18, 2025: The initial version of this used the following for
+    #   z and y bands. Due to a matplotlib bug, this does not work. It should be
+    #   restored to this behavior beginning with rubinenv 11, if possible.
+    # "z": (0, (3, 5, 1, 5, 1, 5)),
+    # "y": (0, (3, 1, 1, 1)),
+
     return plot_line_styles

--- a/python/lsst/utils/plotting/figures.py
+++ b/python/lsst/utils/plotting/figures.py
@@ -146,7 +146,7 @@ def get_multiband_plot_linestyles() -> dict:
         "y": ":",
     }
 
-    # Note, Mar. 18, 2025: The initial version of this used the following for
+    # TODO [DM-49724]: The initial version of this used the following for
     #   z and y bands. Due to a matplotlib bug, this does not work. It should
     #   be restored to this behavior beginning with rubinenv 11, if possible.
     # "z": (0, (3, 5, 1, 5, 1, 5)),

--- a/python/lsst/utils/plotting/figures.py
+++ b/python/lsst/utils/plotting/figures.py
@@ -147,8 +147,8 @@ def get_multiband_plot_linestyles() -> dict:
     }
 
     # Note, Mar. 18, 2025: The initial version of this used the following for
-    #   z and y bands. Due to a matplotlib bug, this does not work. It should be
-    #   restored to this behavior beginning with rubinenv 11, if possible.
+    #   z and y bands. Due to a matplotlib bug, this does not work. It should
+    #   be restored to this behavior beginning with rubinenv 11, if possible.
     # "z": (0, (3, 5, 1, 5, 1, 5)),
     # "y": (0, (3, 1, 1, 1)),
 

--- a/python/lsst/utils/plotting/publication_plots.py
+++ b/python/lsst/utils/plotting/publication_plots.py
@@ -10,28 +10,35 @@
 # license that can be found in the LICENSE file.
 """Utilities for making publication-quality figures."""
 
-import matplotlib.pyplot
-
-import lsst.utils.plotting
-
 __all__ = [
     "get_band_dicts",
     "set_rubin_plotstyle",
 ]
+
+from matplotlib import style
+
+from lsst.utils import getPackageDir
+from . import (
+    get_multiband_plot_colors,
+    get_multiband_plot_linestyles,
+    get_multiband_plot_symbols,
+)
 
 
 def set_rubin_plotstyle() -> None:
     """
     Set the matplotlib style for Rubin publications
     """
-    matplotlib.pyplot.style.use("lsst.utils.plotting.rubin")
-    print("Set up Rubin matplotlib plot style.")
+    utilsPath = getPackageDir("utils")
+    styleFile = utilsPath + "/python/lsst/utils/plotting/rubin.mplstyle"
+    style.use(styleFile)
 
 
 def get_band_dicts() -> dict:
     """
-    Define palettes, from RTN-045.
-    Module works with LSST Science Pipelines version >= daily 2024_12_02
+    Define palettes, from RTN-045. This includes dicts for colors (bandpass
+    colors for white background), colors_black (bandpass colors for
+    black background), plot symbols, and line_styles, keyed on band (ugrizy).
 
     Returns
     -------
@@ -39,14 +46,10 @@ def get_band_dicts() -> dict:
         Dicts of colors, colors_black, symbols, and line_styles,
         keyed on bands 'u', 'g', 'r', 'i', 'z', and 'y'.
     """
-    colors = lsst.utils.plotting.get_multiband_plot_colors()
-    colors_black = lsst.utils.plotting.get_multiband_plot_colors(dark_background=True)
-    symbols = lsst.utils.plotting.get_multiband_plot_symbols()
-    line_styles = lsst.utils.plotting.get_multiband_plot_linestyles()
-
-    print("This includes dicts for colors (bandpass colors for white background),")
-    print("  colors_black (bandpass colors for black background), symbols, and line_styles,")
-    print("  keyed on band (ugrizy).")
+    colors = get_multiband_plot_colors()
+    colors_black = get_multiband_plot_colors(dark_background=True)
+    symbols = get_multiband_plot_symbols()
+    line_styles = get_multiband_plot_linestyles()
 
     return {
         "colors": colors,

--- a/python/lsst/utils/plotting/publication_plots.py
+++ b/python/lsst/utils/plotting/publication_plots.py
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 
-def set_rubin_plotstyle():
+def set_rubin_plotstyle() -> None:
     """
     Set the matplotlib style for Rubin publications
     """
@@ -32,6 +32,12 @@ def get_band_dicts():
     """
     Define palettes, from RTN-045.
     Module works with LSST Science Pipelines version >= daily 2024_12_02
+
+    Returns
+    -------
+    band_dict : `dict` of `dict`
+        Dicts of colors_white, colors_black, symbols, and line_styles,
+        keyed on bands 'u', 'g', 'r', 'i', 'z', and 'y'.
     """
     colors_white = lsst.utils.plotting.get_multiband_plot_colors()
     colors_black = lsst.utils.plotting.get_multiband_plot_colors(dark_background=True)

--- a/python/lsst/utils/plotting/publication_plots.py
+++ b/python/lsst/utils/plotting/publication_plots.py
@@ -24,8 +24,8 @@ def set_rubin_plotstyle():
     """
     Set the matplotlib style for Rubin publications
     """
-    matplotlib.pyplot.style.use('lsst.utils.plotting.rubin')
-    print('Set up Rubin matplotlib plot style.')
+    matplotlib.pyplot.style.use("lsst.utils.plotting.rubin")
+    print("Set up Rubin matplotlib plot style.")
 
 
 def get_band_dicts():
@@ -38,9 +38,13 @@ def get_band_dicts():
     symbols = lsst.utils.plotting.get_multiband_plot_symbols()
     line_styles = lsst.utils.plotting.get_multiband_plot_linestyles()
 
-    print('This includes dicts for colors_white (bandpass colors for white background),')
-    print('  colors_black (bandpass colors for black background), symbols, and line_styles,')
-    print('  keyed on band (ugrizy).')
+    print("This includes dicts for colors_white (bandpass colors for white background),")
+    print("  colors_black (bandpass colors for black background), symbols, and line_styles,")
+    print("  keyed on band (ugrizy).")
 
-    return {'colors_white': colors_white, 'colors_black': colors_black,
-            'symbols': symbols, 'line_styles': line_styles}
+    return {
+        "colors_white": colors_white,
+        "colors_black": colors_black,
+        "symbols": symbols,
+        "line_styles": line_styles,
+    }

--- a/python/lsst/utils/plotting/publication_plots.py
+++ b/python/lsst/utils/plotting/publication_plots.py
@@ -1,0 +1,46 @@
+# This file is part of utils.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# Use of this source code is governed by a 3-clause BSD-style
+# license that can be found in the LICENSE file.
+"""Utilities for making publication-quality figures."""
+
+import matplotlib.pyplot
+
+import lsst.utils.plotting
+
+__all__ = [
+    "get_band_dicts",
+    "set_rubin_plotstyle",
+]
+
+
+def set_rubin_plotstyle():
+    """
+    Set the matplotlib style for Rubin publications
+    """
+    matplotlib.pyplot.style.use('lsst.utils.plotting.rubin')
+    print('Set up Rubin matplotlib plot style.')
+
+
+def get_band_dicts():
+    """
+    Define palettes, from RTN-045.
+    Module works with LSST Science Pipelines version >= daily 2024_12_02
+    """
+    colors_white = lsst.utils.plotting.get_multiband_plot_colors()
+    colors_black = lsst.utils.plotting.get_multiband_plot_colors(dark_background=True)
+    symbols = lsst.utils.plotting.get_multiband_plot_symbols()
+    line_styles = lsst.utils.plotting.get_multiband_plot_linestyles()
+
+    print('This includes dicts for colors_white (bandpass colors for white background),')
+    print('  colors_black (bandpass colors for black background), symbols, and line_styles,')
+    print('  keyed on band (ugrizy).')
+
+    return {'colors_white': colors_white, 'colors_black': colors_black,
+            'symbols': symbols, 'line_styles': line_styles}

--- a/python/lsst/utils/plotting/publication_plots.py
+++ b/python/lsst/utils/plotting/publication_plots.py
@@ -36,20 +36,20 @@ def get_band_dicts():
     Returns
     -------
     band_dict : `dict` of `dict`
-        Dicts of colors_white, colors_black, symbols, and line_styles,
+        Dicts of colors, colors_black, symbols, and line_styles,
         keyed on bands 'u', 'g', 'r', 'i', 'z', and 'y'.
     """
-    colors_white = lsst.utils.plotting.get_multiband_plot_colors()
+    colors = lsst.utils.plotting.get_multiband_plot_colors()
     colors_black = lsst.utils.plotting.get_multiband_plot_colors(dark_background=True)
     symbols = lsst.utils.plotting.get_multiband_plot_symbols()
     line_styles = lsst.utils.plotting.get_multiband_plot_linestyles()
 
-    print("This includes dicts for colors_white (bandpass colors for white background),")
+    print("This includes dicts for colors (bandpass colors for white background),")
     print("  colors_black (bandpass colors for black background), symbols, and line_styles,")
     print("  keyed on band (ugrizy).")
 
     return {
-        "colors_white": colors_white,
+        "colors": colors,
         "colors_black": colors_black,
         "symbols": symbols,
         "line_styles": line_styles,

--- a/python/lsst/utils/plotting/publication_plots.py
+++ b/python/lsst/utils/plotting/publication_plots.py
@@ -28,7 +28,7 @@ def set_rubin_plotstyle() -> None:
     print("Set up Rubin matplotlib plot style.")
 
 
-def get_band_dicts():
+def get_band_dicts() -> dict:
     """
     Define palettes, from RTN-045.
     Module works with LSST Science Pipelines version >= daily 2024_12_02

--- a/python/lsst/utils/plotting/rubin.mplstyle
+++ b/python/lsst/utils/plotting/rubin.mplstyle
@@ -1,0 +1,41 @@
+axes.labelweight: 3
+axes.labelsize : large
+axes.linewidth: 2
+axes.titleweight: 2
+axes.titlesize : small
+figure.titlesize: small
+errorbar.capsize: 3.0
+
+lines.linewidth : 3
+lines.markersize : 10
+
+xtick.labelsize : large
+ytick.labelsize : large
+
+figure.dpi : 150.0
+figure.facecolor: White
+# figure.figsize : 6.4, 4.8
+
+# From tableau-colorblind10 style: https://viscid-hub.github.io/Viscid-docs/docs/dev/styles/tableau-colorblind10.html
+axes.prop_cycle: cycler('color', ['006BA4', 'FF800E', 'ABABAB', '595959', '5F9ED1', 'C85200', '898989', 'A2C8EC', 'FFBC79', 'CFCFCF'])
+patch.facecolor: 006BA4
+
+font.size : 14
+legend.fontsize: x-small
+
+xtick.major.width: 2.0
+xtick.minor.width: 1.5
+xtick.major.size: 7
+xtick.minor.size: 4
+xtick.minor.visible: True
+xtick.direction: in
+xtick.top: True
+xtick.bottom: True
+ytick.major.width: 2.0
+ytick.minor.width: 1.5
+ytick.major.size: 7
+ytick.minor.size: 4
+ytick.minor.visible: True
+ytick.direction: in
+ytick.left: True
+ytick.right: True

--- a/python/lsst/utils/plotting/rubin.mplstyle
+++ b/python/lsst/utils/plotting/rubin.mplstyle
@@ -1,7 +1,8 @@
-axes.labelweight: 3
+axes.labelweight: normal
+figure.titleweight : normal
 axes.labelsize : large
 axes.linewidth: 2
-axes.titleweight: 2
+axes.titleweight: normal
 axes.titlesize : small
 figure.titlesize: small
 errorbar.capsize: 3.0
@@ -14,7 +15,7 @@ ytick.labelsize : large
 
 figure.dpi : 150.0
 figure.facecolor: White
-# figure.figsize : 6.4, 4.8
+figure.figsize : 6.4, 4.8
 
 # From tableau-colorblind10 style: https://viscid-hub.github.io/Viscid-docs/docs/dev/styles/tableau-colorblind10.html
 axes.prop_cycle: cycler('color', ['006BA4', 'FF800E', 'ABABAB', '595959', '5F9ED1', 'C85200', '898989', 'A2C8EC', 'FFBC79', 'CFCFCF'])
@@ -39,3 +40,7 @@ ytick.minor.visible: True
 ytick.direction: in
 ytick.left: True
 ytick.right: True
+xtick.major.pad : 6
+xtick.minor.pad : 6
+ytick.major.pad : 6
+ytick.minor.pad : 6

--- a/tests/test_matplotlib_figures.py
+++ b/tests/test_matplotlib_figures.py
@@ -21,12 +21,16 @@
 
 import unittest
 
+import matplotlib.pyplot
+
 import lsst.utils.tests
 from lsst.utils.plotting import (
+    get_band_dicts,
     get_multiband_plot_colors,
     get_multiband_plot_linestyles,
     get_multiband_plot_symbols,
     make_figure,
+    set_rubin_plotstyle,
 )
 
 try:
@@ -69,3 +73,21 @@ class MakeFigureTestCase(unittest.TestCase):
                     )
 
             fig.savefig(tmpFile)
+
+
+@unittest.skipIf(Figure is None, "matplotlib is not available.")
+class PublicationPlotsTestCase(unittest.TestCase):
+    """Tests for publication_plots."""
+
+    def testMplStyle(self):
+        # Set the plot style
+        set_rubin_plotstyle()
+        # Confirm that the settings took effect by checking one of them
+        self.assertEqual(matplotlib.pyplot.rcParams['errorbar.capsize'], 3.0)
+
+    def testMultibandPlotColors(self):
+        bands_dict = get_band_dicts()
+        self.assertEqual(bands_dict['colors']['r'], '#c61c00')
+        self.assertEqual(bands_dict['colors_black']['r'], '#ff7e00')
+        self.assertEqual(bands_dict['symbols']['r'], 'v')
+        self.assertEqual(bands_dict['line_styles']['r'], '-')

--- a/tests/test_matplotlib_figures.py
+++ b/tests/test_matplotlib_figures.py
@@ -21,7 +21,7 @@
 
 import unittest
 
-import matplotlib.pyplot
+from matplotlib import rcParams
 
 import lsst.utils.tests
 from lsst.utils.plotting import (
@@ -83,7 +83,7 @@ class PublicationPlotsTestCase(unittest.TestCase):
         # Set the plot style
         set_rubin_plotstyle()
         # Confirm that the settings took effect by checking one of them
-        self.assertEqual(matplotlib.pyplot.rcParams["errorbar.capsize"], 3.0)
+        self.assertEqual(rcParams["errorbar.capsize"], 3.0)
 
     def testMultibandPlotColors(self):
         bands_dict = get_band_dicts()

--- a/tests/test_matplotlib_figures.py
+++ b/tests/test_matplotlib_figures.py
@@ -83,11 +83,11 @@ class PublicationPlotsTestCase(unittest.TestCase):
         # Set the plot style
         set_rubin_plotstyle()
         # Confirm that the settings took effect by checking one of them
-        self.assertEqual(matplotlib.pyplot.rcParams['errorbar.capsize'], 3.0)
+        self.assertEqual(matplotlib.pyplot.rcParams["errorbar.capsize"], 3.0)
 
     def testMultibandPlotColors(self):
         bands_dict = get_band_dicts()
-        self.assertEqual(bands_dict['colors']['r'], '#c61c00')
-        self.assertEqual(bands_dict['colors_black']['r'], '#ff7e00')
-        self.assertEqual(bands_dict['symbols']['r'], 'v')
-        self.assertEqual(bands_dict['line_styles']['r'], '-')
+        self.assertEqual(bands_dict["colors"]["r"], "#c61c00")
+        self.assertEqual(bands_dict["colors_black"]["r"], "#ff7e00")
+        self.assertEqual(bands_dict["symbols"]["r"], "v")
+        self.assertEqual(bands_dict["line_styles"]["r"], "-")


### PR DESCRIPTION
The module can be import using:
`from lsst.utils.plotting import publication_plots`

To set the plot style (in python):
`publication_plots.set_rubin_plotstyle()`

To retrieve the dicts defining per-band colors, symbols, and linestyles:
`bands_dict = publication_plots.get_band_dicts()`

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
