### PR TITLE
DM-44862: Provide defaults for DbAuth constructor

### DIFF
--- a/doc/changes/DM-44862.api.md
+++ b/doc/changes/DM-44862.api.md
@@ -1,0 +1,2 @@
+DbAuth constructor now provides default values for path and environment variable name.
+This avoids the need to specify the same values in each package that uses DbAuth.

--- a/python/lsst/utils/db_auth.py
+++ b/python/lsst/utils/db_auth.py
@@ -30,6 +30,13 @@ import yaml
 
 __all__ = ["DbAuth", "DbAuthError", "DbAuthPermissionsError"]
 
+DB_AUTH_ENVVAR = "LSST_DB_AUTH"
+"""Default name of the environmental variable that will be used to locate DB
+credentials configuration file. """
+
+DB_AUTH_PATH = "~/.lsst/db-auth.yaml"
+"""Default path at which it is expected that DB credentials are found."""
+
 
 class DbAuthError(RuntimeError):
     """Exception raised when a problem has occurred retrieving database
@@ -57,9 +64,10 @@ class DbAuth:
     Parameters
     ----------
     path : `str` or None, optional
-        Path to configuration file.
+        Path to configuration file, default path is ``~/.lsst/db-auth.yaml``.
     envVar : `str` or None, optional
-        Name of environment variable pointing to configuration file.
+        Name of environment variable pointing to configuration file, default is
+        ``LSST_DB_AUTH``.
     authList : `list` [`dict`] or None, optional
         Authentication configuration.
 
@@ -78,12 +86,8 @@ class DbAuth:
         if authList is not None:
             self.authList = authList
             return
-        if envVar is not None and envVar in os.environ:
-            secretPath = os.path.expanduser(os.environ[envVar])
-        elif path is None:
-            raise DbAuthNotFoundError("No default path provided to DbAuth configuration file")
-        else:
-            secretPath = os.path.expanduser(path)
+        secretPath = os.environ.get(envVar or DB_AUTH_ENVVAR, path or DB_AUTH_PATH)
+        secretPath = os.path.expanduser(secretPath)
         if not os.path.isfile(secretPath):
             raise DbAuthNotFoundError(f"No DbAuth configuration file: {secretPath}")
         mode = os.stat(secretPath).st_mode

--- a/python/lsst/utils/db_auth.py
+++ b/python/lsst/utils/db_auth.py
@@ -84,6 +84,7 @@ class DbAuth:
         authList: list[dict[str, str]] | None = None,
     ):
         if authList is not None:
+            self._db_auth_path = "<auth-list>"
             self.authList = authList
             return
         secretPath = os.environ.get(envVar or DB_AUTH_ENVVAR, path or DB_AUTH_PATH)
@@ -101,6 +102,12 @@ class DbAuth:
                 self.authList = yaml.safe_load(secretFile)
         except Exception as exc:
             raise DbAuthError(f"Unable to load DbAuth configuration file: {secretPath}.") from exc
+        self._db_auth_path = secretPath
+
+    @property
+    def db_auth_path(self) -> str:
+        """The path to the secrets file used to load credentials (`str`)."""
+        return self._db_auth_path
 
     # dialectname, host, and database are tagged as Optional only because other
     # routines delegate to this one in order to raise a consistent exception

--- a/tests/test_db_auth.py
+++ b/tests/test_db_auth.py
@@ -72,6 +72,7 @@ class DbAuthTestCase(unittest.TestCase):
         filePath = os.path.join(TESTDIR, "db-auth.yaml")
         os.chmod(filePath, 0o600)
         auth = DbAuth(filePath)
+        self.assertEqual(auth.db_auth_path, filePath)
         self.assertEqual(
             auth.getAuth("postgresql", "user", "host.example.com", "5432", "my_database"), ("user", "test1")
         )

--- a/tests/test_db_auth.py
+++ b/tests/test_db_auth.py
@@ -169,8 +169,6 @@ class DbAuthTestCase(unittest.TestCase):
 
     def test_errors(self):
         """Test for error exceptions."""
-        with self.assertRaisesRegex(DbAuthError, r"^No default path provided to DbAuth configuration file$"):
-            auth = DbAuth()
         with self.assertRaisesRegex(DbAuthError, r"^No DbAuth configuration file: .*this_does_not_exist$"):
             auth = DbAuth(os.path.join(TESTDIR, "this_does_not_exist"))
         with self.assertRaisesRegex(DbAuthError, r"^No DbAuth configuration file: .*this_does_not_exist$"):


### PR DESCRIPTION
DbAuth required either the name of the file or envvar (or both)
for its constructor, but did not specify defaults. As a result
few packages had to define those to be the same in each package.
It is better to keep these values in one location and use them
as defautlts for constructor.

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
