### PR TITLE
DM-48671: add node name to task metadata

### DIFF
--- a/doc/changes/DM-48671.feature.rst
+++ b/doc/changes/DM-48671.feature.rst
@@ -1,0 +1,1 @@
+* Added the name of the node on which the process is running to the ``obj.metadata`` written by the logger.

--- a/python/lsst/utils/timer.py
+++ b/python/lsst/utils/timer.py
@@ -20,6 +20,7 @@ import datetime
 import functools
 import logging
 import os
+import platform
 import sys
 import time
 import traceback
@@ -212,6 +213,9 @@ def logInfo(
         # Force a version number into the metadata.
         # v1: Ensure that max_rss field is always bytes.
         metadata["__version__"] = 1
+
+        # Add node information.
+        metadata["nodeName"] = platform.node()
     if stacklevel is not None:
         # Account for the caller of this routine not knowing that we
         # are going one down in the stack.

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -114,6 +114,7 @@ class TestTimeMethod(unittest.TestCase):
         self.assertEqual(cm.records[0].filename, THIS_FILE)
         self.assertIn("PrefixUtc", metadata)
         self.assertIn("PrefixMaxResidentSetSize", metadata)
+        self.assertIn("nodeName", metadata)
         self.assertEqual(metadata["__version__"], 1)
 
         # Again with no log output.


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
