### PR TITLE
DM-49860: Allow DbAuth to read creds from environment JSON string

### DIFF
--- a/doc/changes/DM-49860.feature.rst
+++ b/doc/changes/DM-49860.feature.rst
@@ -1,0 +1,2 @@
+``DbAuth`` now supports reading the credentials directly from a JSON string stored in an environment variable.
+The default environment variable is ``LSST_DB_AUTH_CREDENTIALS`` and takes priority over reading from files.


### PR DESCRIPTION

@tcjennings does this do what you need?

@andy-slac we desperately need to switch to pydantic internally for validation...

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
