### PR TITLE
DM-51381: Ensure subTest arguments are strings.

### DIFF
--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -1014,7 +1014,7 @@ def methodParameters(**settings: Sequence[Any]) -> Callable:
         def wrapper(self: unittest.TestCase, *args: Any, **kwargs: Any) -> None:
             for params in _settingsIterator(settings):
                 kwargs.update(params)
-                with self.subTest(**params):
+                with self.subTest(**{k: repr(v) for k, v in params.items()}):
                     func(self, *args, **kwargs)
 
         return wrapper

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -164,7 +164,7 @@ class TestTimeMethod(unittest.TestCase):
 
         duration = 0.1
         for log, metadata in parameters:
-            with self.subTest(log=log, metadata=metadata):
+            with self.subTest(log=repr(log), metadata=repr(metadata)):
                 task = Example1(log=log, metadata=metadata)
                 self.assertTimer(duration, task)
                 exampleDuration = duration_from_timeMethod(task.metadata, "sleeper")


### PR DESCRIPTION
pytest-xdist chokes on the error messages otherwise, causing the test to fail.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
