### PR TITLE
DM-51451: Get the new colorblind-friendly `ugrizy` color definitions merged into `lsst.utils`

### DIFF
--- a/doc/changes/DM-51451.misc.rst
+++ b/doc/changes/DM-51451.misc.rst
@@ -1,0 +1,1 @@
+Updated multiband plot colors (with white background) for improved colorblind accessibility, as proposed in DM-51451.

--- a/python/lsst/utils/plotting/figures.py
+++ b/python/lsst/utils/plotting/figures.py
@@ -81,12 +81,12 @@ def get_multiband_plot_colors(dark_background: bool = False) -> dict:
         Mapping of the LSST bands to colors.
     """
     plot_filter_colors_white_background = {
-        "u": "#0c71ff",
-        "g": "#49be61",
-        "r": "#c61c00",
-        "i": "#ffc200",
-        "z": "#f341a2",
-        "y": "#5d0000",
+        "u": "#61A2B3",
+        "g": "#31DE1F",
+        "r": "#B52626",
+        "i": "#1600EA",
+        "z": "#BA52FF",
+        "y": "#370201",
     }
     plot_filter_colors_black_background = {
         "u": "#3eb7ff",

--- a/tests/test_matplotlib_figures.py
+++ b/tests/test_matplotlib_figures.py
@@ -93,7 +93,7 @@ class PublicationPlotsTestCase(unittest.TestCase):
 
     def testMultibandPlotColors(self):
         bands_dict = get_band_dicts()
-        self.assertEqual(bands_dict["colors"]["r"], "#c61c00")
+        self.assertEqual(bands_dict["colors"]["r"], "#B52626")
         self.assertEqual(bands_dict["colors_black"]["r"], "#ff7e00")
         self.assertEqual(bands_dict["symbols"]["r"], "v")
         self.assertEqual(bands_dict["line_styles"]["r"], "-.")


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
