### PR TITLE
DM-51290: Fix type annotations for timeMethod.

### DIFF
--- a/python/lsst/utils/timer.py
+++ b/python/lsst/utils/timer.py
@@ -27,7 +27,7 @@ import time
 import traceback
 from collections.abc import Callable, Collection, Iterable, Iterator, MutableMapping
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 from astropy import units as u
 
@@ -231,6 +231,19 @@ def logInfo(
         logger=logger,
         stacklevel=stacklevel,
     )
+
+
+@overload
+def timeMethod[F: Callable](_func: F) -> F: ...
+
+
+@overload
+def timeMethod[F](
+    *,
+    metadata: MutableMapping | None = None,
+    logger: LsstLoggers | None = None,
+    logLevel: int = logging.DEBUG,
+) -> Callable[[F], F]: ...
 
 
 def timeMethod(

--- a/python/lsst/utils/timer.py
+++ b/python/lsst/utils/timer.py
@@ -27,7 +27,7 @@ import time
 import traceback
 from collections.abc import Callable, Collection, Iterable, Iterator, MutableMapping
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 from astropy import units as u
 
@@ -233,17 +233,20 @@ def logInfo(
     )
 
 
-@overload
-def timeMethod[F: Callable](_func: F) -> F: ...
+_F = TypeVar("_F", bound=Callable)
 
 
 @overload
-def timeMethod[F](
+def timeMethod(_func: _F) -> _F: ...
+
+
+@overload
+def timeMethod(
     *,
     metadata: MutableMapping | None = None,
     logger: LsstLoggers | None = None,
     logLevel: int = logging.DEBUG,
-) -> Callable[[F], F]: ...
+) -> Callable[[_F], _F]: ...
 
 
 def timeMethod(


### PR DESCRIPTION
Using this as a decorator no longer obliterates the annotations on the decorated function.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
