### PR TITLE
DM-55482: Improve coverage of disable_implicit_threading

### DIFF
--- a/doc/changes/DM-55482.bugfix.rst
+++ b/doc/changes/DM-55482.bugfix.rst
@@ -1,4 +1,5 @@
 Improved the coverage of ``disable_implicit_threading``.
 The thread-related environment variables now also include ``NUMBA_NUM_THREADS``, ``ARROW_IO_THREADS``, ``VECLIB_MAXIMUM_THREADS``, ``RAYON_NUM_THREADS``, ``POLARS_MAX_THREADS``, and ``BLIS_NUM_THREADS``.
 Existing ``pyarrow`` thread pools are now resized explicitly since they do not react to environment variables after creation.
+An already-imported ``numba`` is now limited at runtime since it reads its environment variable only at import time.
 A warning is now logged if ``threadpoolctl`` is not installed since thread pools of already-loaded libraries can then no longer be limited.

--- a/doc/changes/DM-55482.bugfix.rst
+++ b/doc/changes/DM-55482.bugfix.rst
@@ -1,5 +1,5 @@
 Improved the coverage of ``disable_implicit_threading``.
 The thread-related environment variables now also include ``NUMBA_NUM_THREADS``, ``ARROW_IO_THREADS``, ``VECLIB_MAXIMUM_THREADS``, ``RAYON_NUM_THREADS``, ``POLARS_MAX_THREADS``, and ``BLIS_NUM_THREADS``.
 Existing ``pyarrow`` thread pools are now resized explicitly since they do not react to environment variables after creation.
-An already-imported ``numba`` is now limited at runtime since it reads its environment variable only at import time.
+An already-imported ``numba`` is now limited to a single thread at runtime without breaking subsequent JIT compilation, since its recorded thread count and ``NUMBA_NUM_THREADS`` are kept consistent.
 A warning is now logged if ``threadpoolctl`` is not installed since thread pools of already-loaded libraries can then no longer be limited.

--- a/doc/changes/DM-55482.bugfix.rst
+++ b/doc/changes/DM-55482.bugfix.rst
@@ -1,0 +1,4 @@
+Improved the coverage of ``disable_implicit_threading``.
+The thread-related environment variables now also include ``NUMBA_NUM_THREADS``, ``ARROW_IO_THREADS``, ``VECLIB_MAXIMUM_THREADS``, ``RAYON_NUM_THREADS``, ``POLARS_MAX_THREADS``, and ``BLIS_NUM_THREADS``.
+Existing ``pyarrow`` thread pools are now resized explicitly since they do not react to environment variables after creation.
+A warning is now logged if ``threadpoolctl`` is not installed since thread pools of already-loaded libraries can then no longer be limited.

--- a/python/lsst/utils/threads.py
+++ b/python/lsst/utils/threads.py
@@ -15,12 +15,16 @@ from __future__ import annotations
 
 __all__ = ["disable_implicit_threading", "set_thread_envvars"]
 
+import logging
 import os
+import sys
 
 try:
     from threadpoolctl import threadpool_limits
 except ImportError:
     threadpool_limits = None
+
+_LOG = logging.getLogger(__name__)
 
 
 def set_thread_envvars(num_threads: int = 1, override: bool = False) -> None:
@@ -44,6 +48,12 @@ def set_thread_envvars(num_threads: int = 1, override: bool = False) -> None:
         "MPI_NUM_THREADS",
         "NUMEXPR_NUM_THREADS",
         "NUMEXPR_MAX_THREADS",
+        "NUMBA_NUM_THREADS",
+        "ARROW_IO_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+        "RAYON_NUM_THREADS",
+        "POLARS_MAX_THREADS",
+        "BLIS_NUM_THREADS",
     )
 
     for var in envvars:
@@ -63,8 +73,8 @@ def disable_implicit_threading() -> None:
     Notes
     -----
     Explicitly limits the number of threads allowed to be used by ``numexpr``
-    and attempts to limit the number of threads in all APIs supported by
-    the ``threadpoolctl`` package.
+    and ``pyarrow`` (if already imported) and attempts to limit the number of
+    threads in all APIs supported by the ``threadpoolctl`` package.
     """
     # Force one thread and force override.
     set_thread_envvars(1, True)
@@ -79,6 +89,19 @@ def disable_implicit_threading() -> None:
     else:
         numexpr.utils.set_num_threads(1)
 
+    # pyarrow sizes its thread pools from the environment only when each pool
+    # is first used, so pools that may already exist must be resized
+    # explicitly. If pyarrow has not been imported the environment variables
+    # set above are sufficient and there is no need to pay for an import here.
+    if (pyarrow := sys.modules.get("pyarrow")) is not None:
+        pyarrow.set_cpu_count(1)
+        pyarrow.set_io_thread_count(1)
+
     # Try to set threads for openblas and openmp
     if threadpool_limits is not None:
         threadpool_limits(limits=1)
+    else:
+        _LOG.warning(
+            "threadpoolctl is not installed: thread pools of already-loaded libraries cannot be "
+            "limited and implicit threading may remain enabled."
+        )

--- a/python/lsst/utils/threads.py
+++ b/python/lsst/utils/threads.py
@@ -97,9 +97,26 @@ def disable_implicit_threading() -> None:
         pyarrow.set_cpu_count(1)
         pyarrow.set_io_thread_count(1)
 
-    # numba reads its environment variable only at import time so an
-    # already-imported numba must be limited at runtime.
+    # numba records the value of NUMBA_NUM_THREADS as the maximum size of its
+    # thread pool, and numba.config.reload_config() (which numba runs on every
+    # jit compilation) raises if the environment variable no longer matches
+    # that recorded value once the pool has been launched. The number of
+    # threads actually used defaults to that recorded maximum too, so limiting
+    # an already-imported numba requires masking execution with
+    # set_num_threads in addition to keeping the recorded value and the
+    # environment variable consistent.
     if (numba := sys.modules.get("numba")) is not None:
+        try:
+            # The pool has not been launched yet, so make numba adopt the
+            # NUMBA_NUM_THREADS=1 set above before it launches.
+            numba.config.reload_config()
+        except RuntimeError:
+            # The pool is already running at a size that cannot be lowered, so
+            # numba refuses the new value. Realign NUMBA_NUM_THREADS with the
+            # launched value instead so later reloads stay consistent.
+            os.environ["NUMBA_NUM_THREADS"] = str(numba.config.NUMBA_NUM_THREADS)
+            numba.config.reload_config()
+        # Mask execution down to a single thread.
         numba.set_num_threads(1)
 
     # Try to set threads for openblas and openmp

--- a/python/lsst/utils/threads.py
+++ b/python/lsst/utils/threads.py
@@ -97,6 +97,11 @@ def disable_implicit_threading() -> None:
         pyarrow.set_cpu_count(1)
         pyarrow.set_io_thread_count(1)
 
+    # numba reads its environment variable only at import time so an
+    # already-imported numba must be limited at runtime.
+    if (numba := sys.modules.get("numba")) is not None:
+        numba.set_num_threads(1)
+
     # Try to set threads for openblas and openmp
     if threadpool_limits is not None:
         threadpool_limits(limits=1)

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -21,6 +21,7 @@
 
 import os
 import unittest
+import unittest.mock
 
 from lsst.utils.threads import disable_implicit_threading, set_thread_envvars
 
@@ -32,6 +33,10 @@ try:
     import threadpoolctl
 except ImportError:
     threadpoolctl = None
+try:
+    import pyarrow
+except ImportError:
+    pyarrow = None
 
 
 class ThreadsTestCase(unittest.TestCase):
@@ -54,6 +59,44 @@ class ThreadsTestCase(unittest.TestCase):
             info = threadpoolctl.threadpool_info()
             for api in info:
                 self.assertEqual(api["num_threads"], 1, f"API: {api}")
+
+    def testEnvVarsForEnvOnlyLibraries(self):
+        """Libraries that are only controllable via environment variables
+        must be included in the list of variables that are set.
+        """
+        set_thread_envvars(2, override=True)
+        for var in (
+            "NUMBA_NUM_THREADS",
+            "ARROW_IO_THREADS",
+            "VECLIB_MAXIMUM_THREADS",
+            "RAYON_NUM_THREADS",
+            "POLARS_MAX_THREADS",
+            "BLIS_NUM_THREADS",
+        ):
+            self.assertEqual(os.environ.get(var), "2", f"Variable: {var}")
+
+    @unittest.skipIf(pyarrow is None, "pyarrow is not available")
+    def testDisablePyarrow(self):
+        """Already-created pyarrow thread pools must be resized since they
+        do not react to environment variables after creation.
+        """
+        pyarrow.set_cpu_count(4)
+        pyarrow.set_io_thread_count(4)
+        disable_implicit_threading()
+        self.assertEqual(pyarrow.cpu_count(), 1)
+        self.assertEqual(pyarrow.io_thread_count(), 1)
+
+    @unittest.skipIf(threadpoolctl is None, "threadpoolctl is not available")
+    def testMissingThreadpoolctlWarning(self):
+        """Absence of threadpoolctl silently weakens the thread disabling
+        so it must be reported.
+        """
+        with (
+            unittest.mock.patch("lsst.utils.threads.threadpool_limits", None),
+            self.assertLogs("lsst.utils.threads", "WARNING") as cm,
+        ):
+            disable_implicit_threading()
+        self.assertIn("threadpoolctl", "\n".join(cm.output))
 
 
 if __name__ == "__main__":

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -92,12 +92,23 @@ class ThreadsTestCase(unittest.TestCase):
 
     @unittest.skipIf(numba is None, "numba is not available")
     def testDisableNumba(self):
-        """An already-imported numba must be limited at runtime since it
-        reads its environment variable only at import time.
+        """An already-imported numba must be limited to a single thread, and
+        jit compilation afterwards must still work.
         """
         if numba.config.NUMBA_NUM_THREADS > 1:
             numba.set_num_threads(2)
         disable_implicit_threading()
+        self.assertEqual(numba.get_num_threads(), 1)
+
+        # numba re-reads NUMBA_NUM_THREADS every time it reloads its
+        # configuration, which happens on each jit compilation. Compiling a
+        # function must not raise because the environment variable and numba's
+        # recorded thread count disagree.
+        @numba.njit("float64(float64)")
+        def add_one(x: float) -> float:
+            return x + 1.0
+
+        self.assertEqual(add_one(1.0), 2.0)
         self.assertEqual(numba.get_num_threads(), 1)
 
     @unittest.skipIf(threadpoolctl is None, "threadpoolctl is not available")

--- a/tests/test_threads.py
+++ b/tests/test_threads.py
@@ -37,6 +37,10 @@ try:
     import pyarrow
 except ImportError:
     pyarrow = None
+try:
+    import numba
+except ImportError:
+    numba = None
 
 
 class ThreadsTestCase(unittest.TestCase):
@@ -85,6 +89,16 @@ class ThreadsTestCase(unittest.TestCase):
         disable_implicit_threading()
         self.assertEqual(pyarrow.cpu_count(), 1)
         self.assertEqual(pyarrow.io_thread_count(), 1)
+
+    @unittest.skipIf(numba is None, "numba is not available")
+    def testDisableNumba(self):
+        """An already-imported numba must be limited at runtime since it
+        reads its environment variable only at import time.
+        """
+        if numba.config.NUMBA_NUM_THREADS > 1:
+            numba.set_num_threads(2)
+        disable_implicit_threading()
+        self.assertEqual(numba.get_num_threads(), 1)
 
     @unittest.skipIf(threadpoolctl is None, "threadpoolctl is not available")
     def testMissingThreadpoolctlWarning(self):


### PR DESCRIPTION
Add NUMBA_NUM_THREADS, ARROW_IO_THREADS, VECLIB_MAXIMUM_THREADS, RAYON_NUM_THREADS, POLARS_MAX_THREADS, and BLIS_NUM_THREADS to the environment variables set by set_thread_envvars.

Resize existing pyarrow thread pools explicitly since they are sized from the environment only when each pool is first used and do not react to environment variables after creation.

Log a warning when threadpoolctl is not installed since thread pools of already-loaded libraries can then no longer be limited.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
