### PR TITLE
DM-55547: Add perf-NNN.map files to the leak test ignore list

### DIFF
--- a/python/lsst/utils/tests.py
+++ b/python/lsst/utils/tests.py
@@ -159,6 +159,7 @@ class MemoryTestCase(unittest.TestCase):
             and not f.endswith("astropy.log")
             and not f.endswith("mime/mime.cache")
             and not f.endswith(".sqlite3")
+            and not re.search(r"/perf-\d+\.map$", f)
             and not any(re.search(r, f) for r in self.ignore_regexps)
         }
 


### PR DESCRIPTION
These can be generated by the perf-profiling infrastructure in Python, especially with JIT compilation.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
